### PR TITLE
support snarkjs-v0.7

### DIFF
--- a/contracts/Decoder.sol
+++ b/contracts/Decoder.sol
@@ -189,10 +189,8 @@ contract Decoder {
         }
     }
 
-    function verifyDecoding(uint[] memory input, Proof memory proof) public view returns (uint) {
-        require(input.length == 3, "verifier-bad-input");
-        uint[3] memory _pubSignals = [input[0], input[1], input[2]];
-        if (this.verifyProof([proof.A.X, proof.A.Y],[[proof.B.X[0], proof.B.X[1]], [proof.B.Y[0], proof.B.Y[1]]], [proof.C.X, proof.C.Y], _pubSignals))
+    function verifyDecoding(uint[3] memory input, Proof memory proof) public view returns (uint) {
+        if (this.verifyProof([proof.A.X, proof.A.Y],[[proof.B.X[0], proof.B.X[1]], [proof.B.Y[0], proof.B.Y[1]]], [proof.C.X, proof.C.Y], input))
             return 0;
         return 1;
     }

--- a/contracts/Decoder.sol
+++ b/contracts/Decoder.sol
@@ -13,287 +13,188 @@
 // SPDX-License-Identifier: GPL-3.0
 pragma solidity ^0.8.0;
 
-library Pairing {
+contract Decoder {
     struct G1Point {
         uint X;
         uint Y;
     }
-    // Encoding of field elements is: X[0] * z + X[1]
     struct G2Point {
         uint[2] X;
         uint[2] Y;
     }
-
-    /// @return the generator of G1
-    function P1() internal pure returns (G1Point memory) {
-        return G1Point(1, 2);
-    }
-
-    /// @return the generator of G2
-    function P2() internal pure returns (G2Point memory) {
-        // Original code point
-        return
-            G2Point(
-                [
-                    11559732032986387107991004021392285783925812861821192530917403151452391805634,
-                    10857046999023057135944570762232829481370756359578518086990519993285655852781
-                ],
-                [
-                    4082367875863433681332203403145435568316851327593401208105741076214120093531,
-                    8495653923123431417604973247489272438418190587263600148770280649306958101930
-                ]
-            );
-
-        /*
-        // Changed by Jordi point
-        return G2Point(
-            [10857046999023057135944570762232829481370756359578518086990519993285655852781,
-             11559732032986387107991004021392285783925812861821192530917403151452391805634],
-            [8495653923123431417604973247489272438418190587263600148770280649306958101930,
-             4082367875863433681332203403145435568316851327593401208105741076214120093531]
-        );
-*/
-    }
-
-    /// @return r the negation of p, i.e. p.addition(p.negate()) should be zero.
-    function negate(G1Point memory p) internal pure returns (G1Point memory r) {
-        // The prime q in the base field F_q for G1
-        uint q = 21888242871839275222246405745257275088696311157297823662689037894645226208583;
-        if (p.X == 0 && p.Y == 0) return G1Point(0, 0);
-        return G1Point(p.X, q - (p.Y % q));
-    }
-
-    /// @return r the sum of two points of G1
-    function addition(G1Point memory p1, G1Point memory p2) internal view returns (G1Point memory r) {
-        uint[4] memory input;
-        input[0] = p1.X;
-        input[1] = p1.Y;
-        input[2] = p2.X;
-        input[3] = p2.Y;
-        bool success;
-        // solium-disable-next-line security/no-inline-assembly
-        assembly {
-            success := staticcall(sub(gas(), 2000), 6, input, 0xc0, r, 0x60)
-            // Use "invalid" to make gas estimation work
-            switch success
-            case 0 {
-                invalid()
-            }
-        }
-        require(success, "pairing-add-failed");
-    }
-
-    /// @return r the product of a point on G1 and a scalar, i.e.
-    /// p == p.scalar_mul(1) and p.addition(p) == p.scalar_mul(2) for all points p.
-    function scalar_mul(G1Point memory p, uint s) internal view returns (G1Point memory r) {
-        uint[3] memory input;
-        input[0] = p.X;
-        input[1] = p.Y;
-        input[2] = s;
-        bool success;
-        // solium-disable-next-line security/no-inline-assembly
-        assembly {
-            success := staticcall(sub(gas(), 2000), 7, input, 0x80, r, 0x60)
-            // Use "invalid" to make gas estimation work
-            switch success
-            case 0 {
-                invalid()
-            }
-        }
-        require(success, "pairing-mul-failed");
-    }
-
-    /// @return the result of computing the pairing check
-    /// e(p1[0], p2[0]) *  .... * e(p1[n], p2[n]) == 1
-    /// For example pairing([P1(), P1().negate()], [P2(), P2()]) should
-    /// return true.
-    function pairing(G1Point[] memory p1, G2Point[] memory p2) internal view returns (bool) {
-        require(p1.length == p2.length, "pairing-lengths-failed");
-        uint elements = p1.length;
-        uint inputSize = elements * 6;
-        uint[] memory input = new uint[](inputSize);
-        for (uint i = 0; i < elements; i++) {
-            input[i * 6 + 0] = p1[i].X;
-            input[i * 6 + 1] = p1[i].Y;
-            input[i * 6 + 2] = p2[i].X[0];
-            input[i * 6 + 3] = p2[i].X[1];
-            input[i * 6 + 4] = p2[i].Y[0];
-            input[i * 6 + 5] = p2[i].Y[1];
-        }
-        uint[1] memory out;
-        bool success;
-        // solium-disable-next-line security/no-inline-assembly
-        assembly {
-            success := staticcall(sub(gas(), 2000), 8, add(input, 0x20), mul(inputSize, 0x20), out, 0x20)
-            // Use "invalid" to make gas estimation work
-            switch success
-            case 0 {
-                invalid()
-            }
-        }
-        require(success, "pairing-opcode-failed");
-        return out[0] != 0;
-    }
-
-    /// Convenience method for a pairing check for two pairs.
-    function pairingProd2(
-        G1Point memory a1,
-        G2Point memory a2,
-        G1Point memory b1,
-        G2Point memory b2
-    ) internal view returns (bool) {
-        G1Point[] memory p1 = new G1Point[](2);
-        G2Point[] memory p2 = new G2Point[](2);
-        p1[0] = a1;
-        p1[1] = b1;
-        p2[0] = a2;
-        p2[1] = b2;
-        return pairing(p1, p2);
-    }
-
-    /// Convenience method for a pairing check for three pairs.
-    function pairingProd3(
-        G1Point memory a1,
-        G2Point memory a2,
-        G1Point memory b1,
-        G2Point memory b2,
-        G1Point memory c1,
-        G2Point memory c2
-    ) internal view returns (bool) {
-        G1Point[] memory p1 = new G1Point[](3);
-        G2Point[] memory p2 = new G2Point[](3);
-        p1[0] = a1;
-        p1[1] = b1;
-        p1[2] = c1;
-        p2[0] = a2;
-        p2[1] = b2;
-        p2[2] = c2;
-        return pairing(p1, p2);
-    }
-
-    /// Convenience method for a pairing check for four pairs.
-    function pairingProd4(
-        G1Point memory a1,
-        G2Point memory a2,
-        G1Point memory b1,
-        G2Point memory b2,
-        G1Point memory c1,
-        G2Point memory c2,
-        G1Point memory d1,
-        G2Point memory d2
-    ) internal view returns (bool) {
-        G1Point[] memory p1 = new G1Point[](4);
-        G2Point[] memory p2 = new G2Point[](4);
-        p1[0] = a1;
-        p1[1] = b1;
-        p1[2] = c1;
-        p1[3] = d1;
-        p2[0] = a2;
-        p2[1] = b2;
-        p2[2] = c2;
-        p2[3] = d2;
-        return pairing(p1, p2);
-    }
-}
-
-contract Decoder {
-    using Pairing for *;
-    struct VerifyingKey {
-        Pairing.G1Point alfa1;
-        Pairing.G2Point beta2;
-        Pairing.G2Point gamma2;
-        Pairing.G2Point delta2;
-        Pairing.G1Point[] IC;
-    }
     struct Proof {
-        Pairing.G1Point A;
-        Pairing.G2Point B;
-        Pairing.G1Point C;
+        G1Point A;
+        G2Point B;
+        G1Point C;
     }
 
-    function verifyingKey() internal pure returns (VerifyingKey memory vk) {
-        vk.alfa1 = Pairing.G1Point(
-            7506542393861712633345351046961518695186434969159573929710445813801252250723,
-            16226065335411284296170178517395602646321797300570911178122732619405801531786
-        );
+    // Scalar field size
+    uint256 constant r    = 21888242871839275222246405745257275088548364400416034343698204186575808495617;
+    // Base field size
+    uint256 constant q   = 21888242871839275222246405745257275088696311157297823662689037894645226208583;
 
-        vk.beta2 = Pairing.G2Point(
-            [
-                18085759018360810108311053436144684567975240874798592024271494525670832624248,
-                14634453066859375398229234242235662432488733031061395747558146261931733463655
-            ],
-            [
-                5381338245488965956306749233704530527583477992038243832593582681279872987470,
-                15883666510464263642223723115318135885418478949233288914773546058946554436604
-            ]
-        );
-        vk.gamma2 = Pairing.G2Point(
-            [
-                11559732032986387107991004021392285783925812861821192530917403151452391805634,
-                10857046999023057135944570762232829481370756359578518086990519993285655852781
-            ],
-            [
-                4082367875863433681332203403145435568316851327593401208105741076214120093531,
-                8495653923123431417604973247489272438418190587263600148770280649306958101930
-            ]
-        );
-        vk.delta2 = Pairing.G2Point(
-            [
-                12835677679493139045269931295051448329793403398705026697877485711464362140790,
-                10890565504224301114874433160320698556606628868096993643809081156365267213249
-            ],
-            [
-                4820425325906337717692330783154620996810762479415825588979740850757518563223,
-                20093054666161765761327580477678108845241889769892444974271179780900242692838
-            ]
-        );
-        vk.IC = new Pairing.G1Point[](4);
+    // Verification Key data
+    uint256 constant alphax  = 7506542393861712633345351046961518695186434969159573929710445813801252250723;
+    uint256 constant alphay  = 16226065335411284296170178517395602646321797300570911178122732619405801531786;
+    uint256 constant betax1  = 18085759018360810108311053436144684567975240874798592024271494525670832624248;
+    uint256 constant betax2  = 14634453066859375398229234242235662432488733031061395747558146261931733463655;
+    uint256 constant betay1  = 5381338245488965956306749233704530527583477992038243832593582681279872987470;
+    uint256 constant betay2  = 15883666510464263642223723115318135885418478949233288914773546058946554436604;
+    uint256 constant gammax1 = 11559732032986387107991004021392285783925812861821192530917403151452391805634;
+    uint256 constant gammax2 = 10857046999023057135944570762232829481370756359578518086990519993285655852781;
+    uint256 constant gammay1 = 4082367875863433681332203403145435568316851327593401208105741076214120093531;
+    uint256 constant gammay2 = 8495653923123431417604973247489272438418190587263600148770280649306958101930;
+    uint256 constant deltax1 = 12835677679493139045269931295051448329793403398705026697877485711464362140790;
+    uint256 constant deltax2 = 10890565504224301114874433160320698556606628868096993643809081156365267213249;
+    uint256 constant deltay1 = 4820425325906337717692330783154620996810762479415825588979740850757518563223;
+    uint256 constant deltay2 = 20093054666161765761327580477678108845241889769892444974271179780900242692838;
 
-        vk.IC[0] = Pairing.G1Point(
-            15916933300299841326133363619464745675297622793331552584323366408211376395967,
-            2204695882423366014128738034688798906136516188846113906761598291124965575312
-        );
 
-        vk.IC[1] = Pairing.G1Point(
-            4622856607165460859549457180034620471823207414430476098696107310517129298612,
-            8316856443679694570367215915233834858969193163656242228258052534650350302793
-        );
+    uint256 constant IC0x = 15916933300299841326133363619464745675297622793331552584323366408211376395967;
+    uint256 constant IC0y = 2204695882423366014128738034688798906136516188846113906761598291124965575312;
 
-        vk.IC[2] = Pairing.G1Point(
-            5915523109966219878936187973377718245049119188043618969861196210655718832719,
-            19707299613116331139635042453248814599694182156604393507335721697711099774908
-        );
+    uint256 constant IC1x = 4622856607165460859549457180034620471823207414430476098696107310517129298612;
+    uint256 constant IC1y = 8316856443679694570367215915233834858969193163656242228258052534650350302793;
 
-        vk.IC[3] = Pairing.G1Point(
-            11851222670115883100836444147396391086571308795728318034006095130793195411204,
-            21124748331098730840633663986704312647589675061705229552977471659873651158043
-        );
-    }
+    uint256 constant IC2x = 5915523109966219878936187973377718245049119188043618969861196210655718832719;
+    uint256 constant IC2y = 19707299613116331139635042453248814599694182156604393507335721697711099774908;
 
-    function verifyDecoding(uint[] memory input, Proof memory proof) internal view returns (uint) {
-        uint256 snark_scalar_field = 21888242871839275222246405745257275088548364400416034343698204186575808495617;
-        VerifyingKey memory vk = verifyingKey();
-        require(input.length + 1 == vk.IC.length, "verifier-bad-input");
-        // Compute the linear combination vk_x
-        Pairing.G1Point memory vk_x = Pairing.G1Point(0, 0);
-        for (uint i = 0; i < input.length; i++) {
-            require(input[i] < snark_scalar_field, "verifier-gte-snark-scalar-field");
-            vk_x = Pairing.addition(vk_x, Pairing.scalar_mul(vk.IC[i + 1], input[i]));
+    uint256 constant IC3x = 11851222670115883100836444147396391086571308795728318034006095130793195411204;
+    uint256 constant IC3y = 21124748331098730840633663986704312647589675061705229552977471659873651158043;
+
+
+    // Memory data
+    uint16 constant pVk = 0;
+    uint16 constant pPairing = 128;
+
+    uint16 constant pLastMem = 896;
+
+    function verifyProof(uint[2] calldata _pA, uint[2][2] calldata _pB, uint[2] calldata _pC, uint[3] calldata _pubSignals) public view returns (bool) {
+        assembly {
+            function checkField(v) {
+                if iszero(lt(v, q)) {
+                    mstore(0, 0)
+                    return(0, 0x20)
+                }
+            }
+
+        // G1 function to multiply a G1 value(x,y) to value in an address
+            function g1_mulAccC(pR, x, y, s) {
+                let success
+                let mIn := mload(0x40)
+                mstore(mIn, x)
+                mstore(add(mIn, 32), y)
+                mstore(add(mIn, 64), s)
+
+                success := staticcall(sub(gas(), 2000), 7, mIn, 96, mIn, 64)
+
+                if iszero(success) {
+                    mstore(0, 0)
+                    return(0, 0x20)
+                }
+
+                mstore(add(mIn, 64), mload(pR))
+                mstore(add(mIn, 96), mload(add(pR, 32)))
+
+                success := staticcall(sub(gas(), 2000), 6, mIn, 128, pR, 64)
+
+                if iszero(success) {
+                    mstore(0, 0)
+                    return(0, 0x20)
+                }
+            }
+
+            function checkPairing(pA, pB, pC, pubSignals, pMem) -> isOk {
+                let _pPairing := add(pMem, pPairing)
+                let _pVk := add(pMem, pVk)
+
+                mstore(_pVk, IC0x)
+                mstore(add(_pVk, 32), IC0y)
+
+            // Compute the linear combination vk_x
+
+                g1_mulAccC(_pVk, IC1x, IC1y, calldataload(add(pubSignals, 0)))
+
+                g1_mulAccC(_pVk, IC2x, IC2y, calldataload(add(pubSignals, 32)))
+
+                g1_mulAccC(_pVk, IC3x, IC3y, calldataload(add(pubSignals, 64)))
+
+
+            // -A
+                mstore(_pPairing, calldataload(pA))
+                mstore(add(_pPairing, 32), mod(sub(q, calldataload(add(pA, 32))), q))
+
+            // B
+                mstore(add(_pPairing, 64), calldataload(pB))
+                mstore(add(_pPairing, 96), calldataload(add(pB, 32)))
+                mstore(add(_pPairing, 128), calldataload(add(pB, 64)))
+                mstore(add(_pPairing, 160), calldataload(add(pB, 96)))
+
+            // alpha1
+                mstore(add(_pPairing, 192), alphax)
+                mstore(add(_pPairing, 224), alphay)
+
+            // beta2
+                mstore(add(_pPairing, 256), betax1)
+                mstore(add(_pPairing, 288), betax2)
+                mstore(add(_pPairing, 320), betay1)
+                mstore(add(_pPairing, 352), betay2)
+
+            // vk_x
+                mstore(add(_pPairing, 384), mload(add(pMem, pVk)))
+                mstore(add(_pPairing, 416), mload(add(pMem, add(pVk, 32))))
+
+
+            // gamma2
+                mstore(add(_pPairing, 448), gammax1)
+                mstore(add(_pPairing, 480), gammax2)
+                mstore(add(_pPairing, 512), gammay1)
+                mstore(add(_pPairing, 544), gammay2)
+
+            // C
+                mstore(add(_pPairing, 576), calldataload(pC))
+                mstore(add(_pPairing, 608), calldataload(add(pC, 32)))
+
+            // delta2
+                mstore(add(_pPairing, 640), deltax1)
+                mstore(add(_pPairing, 672), deltax2)
+                mstore(add(_pPairing, 704), deltay1)
+                mstore(add(_pPairing, 736), deltay2)
+
+
+                let success := staticcall(sub(gas(), 2000), 8, _pPairing, 768, _pPairing, 0x20)
+
+                isOk := and(success, mload(_pPairing))
+            }
+
+            let pMem := mload(0x40)
+            mstore(0x40, add(pMem, pLastMem))
+
+        // Validate that all evaluations ∈ F
+
+            checkField(calldataload(add(_pubSignals, 0)))
+
+            checkField(calldataload(add(_pubSignals, 32)))
+
+            checkField(calldataload(add(_pubSignals, 64)))
+
+            checkField(calldataload(add(_pubSignals, 96)))
+
+
+        // Validate all evaluations
+            let isValid := checkPairing(_pA, _pB, _pC, _pubSignals, pMem)
+
+            mstore(0, isValid)
+            return(0, 0x20)
         }
-        vk_x = Pairing.addition(vk_x, vk.IC[0]);
-        if (
-            !Pairing.pairingProd4(
-                Pairing.negate(proof.A),
-                proof.B,
-                vk.alfa1,
-                vk.beta2,
-                vk_x,
-                vk.gamma2,
-                proof.C,
-                vk.delta2
-            )
-        ) return 1;
-        return 0;
+    }
+
+    function verifyDecoding(uint[] memory input, Proof memory proof) public view returns (uint) {
+        require(input.length == 3, "verifier-bad-input");
+        uint[3] memory _pubSignals = [input[0], input[1], input[2]];
+        if (this.verifyProof([proof.A.X, proof.A.Y],[[proof.B.X[0], proof.B.X[1]], [proof.B.Y[0], proof.B.Y[1]]], [proof.C.X, proof.C.Y], _pubSignals))
+            return 0;
+        return 1;
     }
 
     /// @return r  bool true if proof is valid

--- a/contracts/EthStorageContract.sol
+++ b/contracts/EthStorageContract.sol
@@ -69,7 +69,7 @@ contract EthStorageContract is StorageContract, Decoder {
         uint256 modulusBn254 = 0x30644e72e131a029b85045b68181585d2833e84879b9709143e1f593f0000001;
         uint256 xBn254 = modExp(ruBn254, sampleIdxInKv, modulusBn254);
 
-        uint256[] memory input = new uint256[](3);
+        uint256[3] memory input;
         // TODO: simple hash to curve mapping
         input[0] = encodingKey % modulusBn254;
         input[1] = xBn254;


### PR DESCRIPTION
The decoder contract is based on snarkjs-v0.7, it fixes some v0.5 bugs. https://medium.com/@Beosin_com/beosin-security-researchers-discovered-snarkjs-library-vulnerability-cve-2023-33252-7e64f487c73c

Compared with the v0.5 version, v0.7 has been optimized for gas. The gas cost of v0.7 is 204761, which is 13701 less than that of v0.5.

In order to optimize gas, the function parameter of v0.7 is of type calldata. Try to change calldata to memory and use mload, but the verification fails.

The custom function is "verifyDecoding", and the others are snarkjs default codes.  
Unit tests have passed.