### PR TITLE
bit reverse

### DIFF
--- a/contracts/EthStorageContract.sol
+++ b/contracts/EthStorageContract.sol
@@ -84,7 +84,8 @@ contract EthStorageContract is StorageContract, Decoder {
         bytes memory peInput
     ) public view returns (bool) {
         uint256 ruBls = 0x564c0a11a0f704f4fc3e8acfe0f8245f0ad1347b378fbf96e206da11a5d36306;
-        uint256 modulusBls = 0x73eda753299d7d483339d80809a1d80553bda402fffe5bfeffffffff00000001; // peInput includes an input point that comes from bit reversed sampleIdxInKv
+        uint256 modulusBls = 0x73eda753299d7d483339d80809a1d80553bda402fffe5bfeffffffff00000001;
+        // peInput includes an input point that comes from bit reversed sampleIdxInKv
         uint256 sampleIdxInKvRev = reverse12Bits(sampleIdxInKv);
         uint256 xBls = modExp(ruBls, sampleIdxInKvRev, modulusBls);
         // xBls uses big-endian but the format according to the specs is little-endian, so we need to reverse it.


### PR DESCRIPTION
A bit-reverse operation is performed before compute the root of unity of  `sampleIdxInKv`. 
When the KZG proof is generated, the `x` value in `peInput` is a root of unity of bit-reversed `sampleIdxInKv`.  This is because the roots of KZG domain is in bit-reversed order, according to the spec: https://github.com/ethereum/consensus-specs/blob/50a3f8e8d902ad9d677ca006302eb9535d56d758/specs/deneb/polynomial-commitments.md#bit_reversal_permutation
The implementation of `reverse12Bits` method refers to https://github.com/starkware-libs/starkex-contracts/blob/aecf37f2278b2df233edd13b686d0aa9462ada02/evm-verifier/solidity/contracts/FriLayer.sol#L153






















































































































































































































































































































































































































































































































































































































































































































































































