### PR TITLE
memory bug when return from precompile

### DIFF
--- a/contracts/DecentralizedKV.sol
+++ b/contracts/DecentralizedKV.sol
@@ -106,7 +106,7 @@ contract DecentralizedKV {
     }
 
     // Return the keyed data given off and len.  This function can be only called in JSON-RPC context of ES L2 node.
-    function get(bytes32 key, uint256 off, uint256 len) public view virtual returns (bytes memory result) {
+    function get(bytes32 key, uint256 off, uint256 len) public view virtual returns (bytes memory) {
         require(len > 0, "data len should be non zero");
 
         bytes32 skey = keccak256(abi.encode(msg.sender, key));
@@ -114,11 +114,12 @@ contract DecentralizedKV {
         require(paddr.hash != 0, "data not exist");
         require(paddr.kvSize >= off + len, "beyond the range of kvSize");
         bytes memory input = abi.encode(paddr.kvIdx, off, len, paddr.hash);
+        bytes memory output = new bytes(len);
 
         uint256 retSize = 0;
 
         assembly {
-            if iszero(staticcall(not(0), 0x33301, add(input, 0x20), 0x80, 0x0, len)) {
+            if iszero(staticcall(not(0), 0x33301, add(input, 0x20), 0x80, add(output, 0x20), len)) {
                 revert(0, 0)
             }
             retSize := returndatasize()
@@ -128,17 +129,7 @@ contract DecentralizedKV {
         // and it will simply return immediately instead of revert
         require(retSize > 0, "get() must be called on ES node");
 
-        assembly {
-            // Allocate memory for the result
-            result := mload(0x40)
-            mstore(result, returndatasize())
-
-            // Update free memory pointer
-            mstore(0x40, add(result, add(returndatasize(), 0x20)))
-
-            // Copy the result to the allocated memory
-            returndatacopy(add(result, 0x20), 0, returndatasize())
-        }
+        return output;
     }
 
     // Remove an existing KV pair to a recipient.  Refund the cost accordingly.

--- a/scripts/deploy.js
+++ b/scripts/deploy.js
@@ -17,7 +17,8 @@ async function main() {
     0, // dcfFactor
     1048576, // nonceLimit
     "0x0000000000000000000000000000000000000000", // treasury
-    0 // prepaidAmount
+    0, // prepaidAmount
+    { gasPrice: 30000000000 }
   );
   await storageContract.deployed();
   console.log("storage contract address is ", storageContract.address);


### PR DESCRIPTION
The output memory offset should be allocated instead of just using 0, otherwise, the memory may be set incorrectly.

After the change, the full blob data (131k) can be obtained from get() function in eth_call rpc.