### PR TITLE
Using encode_type as the precompile params

### DIFF
--- a/contracts/TestDecentralizedKV.sol
+++ b/contracts/TestDecentralizedKV.sol
@@ -30,7 +30,12 @@ contract TestDecentralizedKV is DecentralizedKV {
         dataMap[kvIdx] = data;
     }
 
-    function get(bytes32 key, bool needDecode, uint256 off, uint256 len) public view override returns (bytes memory) {
+    function get(
+        bytes32 key,
+        DecodeType decodeType,
+        uint256 off,
+        uint256 len
+    ) public view override returns (bytes memory) {
         if (len == 0) {
             return new bytes(0);
         }


### PR DESCRIPTION
Easy support for more encode/decode types

The whole changes are across three repos:
The related PR in storage contract is [here](https://github.com/ethstorage/storage-contracts-v1/pull/31), the related PR in es-node is [here](https://github.com/ethstorage/es-node/pull/47), and the related PR in es-geth is [here](https://github.com/ethstorage/es-geth/pull/1)