### PR TITLE
Check file size

### DIFF
--- a/contracts/DecentralizedKV.sol
+++ b/contracts/DecentralizedKV.sol
@@ -123,7 +123,7 @@ contract DecentralizedKV {
         PhyAddr memory paddr = kvMap[skey];
         require(paddr.hash != 0, "data not exist");
         if (decodeType == DecodeType.PaddingPer31Bytes) {
-            // ksSize is file size
+            // kvSize is the actual data size that dApp contract stores
             require((paddr.kvSize >= off + len) && (off + len <= maxKvSize - 4096), "beyond the range of kvSize");
         } else {
             // maxKvSize is blob size

--- a/contracts/DecentralizedKV.sol
+++ b/contracts/DecentralizedKV.sol
@@ -122,7 +122,13 @@ contract DecentralizedKV {
         bytes32 skey = keccak256(abi.encode(msg.sender, key));
         PhyAddr memory paddr = kvMap[skey];
         require(paddr.hash != 0, "data not exist");
-        require(paddr.kvSize >= off + len, "beyond the range of kvSize");
+        if (decodeType == DecodeType.PaddingPer31Bytes) {
+            // ksSize is file size
+            require((paddr.kvSize >= off + len) && (off + len <= maxKvSize - 4096), "beyond the range of kvSize");
+        } else {
+            // maxKvSize is blob size
+            require(maxKvSize >= off + len, "beyond the range of maxKvSize");
+        }
         bytes memory input = abi.encode(paddr.kvIdx, decodeType, off, len, paddr.hash);
         bytes memory output = new bytes(len);
 


### PR DESCRIPTION
The kvSize stored in the contract is the actual size of the file, but what is actually stored is a fixed-size blob. Therefore, when the retrieval mode is "RawData", it should be determined based on the size of the blob. When the retrieval mode is "PaddingPer31Bytes", the range of the retrieved data should be 0 ~ (blobSize - 4096)