### PR TITLE
The upfront payment for the first kv in shard 0 is underpriced

### DIFF
--- a/contracts/StorageContract.sol
+++ b/contracts/StorageContract.sol
@@ -98,7 +98,8 @@ abstract contract StorageContract is DecentralizedKV {
     function upfrontPayment() public view virtual override returns (uint256) {
         uint256 totalEntries = lastKvIdx + 1; // include the one to be put
         uint256 shardId = lastKvIdx >> shardEntryBits; // shard id of the new KV
-        if ((totalEntries % (1 << shardEntryBits)) == 1) {
+        // shard0 is already opened in constructor       
+        if ((totalEntries % (1 << shardEntryBits)) == 1 && shardId != 0) {
             // Open a new shard if the KV is the first one of the shard
             // and mark the shard is ready to mine.
             // (TODO): Setup shard difficulty as current difficulty / factor?


### PR DESCRIPTION
It is related to https://github.com/ethstorage/storage-contracts-v1/issues/29. The logic in _prepareAppendWithTimestamp and upfrontPayment are different, so the value returned by upfrontPayment() is smaller than what it calculates in _prepareAppendWithTimestamp()