### PR TITLE
Fix randao test

### DIFF
--- a/test/lib/prover.js
+++ b/test/lib/prover.js
@@ -43,9 +43,12 @@ async function generateRandaoProof(block) {
     block.timestamp,
     block.extraData,
     block.mixHash,
-    block.nonce,
-    "0x",
-    block.withdrawalsRoot
+    '0x0000000000000000',
+    block.baseFeePerGas,
+    block.withdrawalsRoot,
+    block.blobGasUsed,
+    block.excessBlobGas,
+    block.parentBeaconBlockRoot,
   ];
 
   return RLP.encode(header);


### PR DESCRIPTION
Addressing https://github.com/ethstorage/storage-contracts-v1/issues/84, use the correct header items of Cancun era.