### PR TITLE
Make the contract upgradable for our Sepolia deployed contract

### DIFF
--- a/contracts/DecentralizedKV.sol
+++ b/contracts/DecentralizedKV.sol
@@ -19,6 +19,11 @@ contract DecentralizedKV is OwnableUpgradeable {
     uint256 public immutable dcfFactor;
     uint256 public immutable startTime;
     uint256 public immutable maxKvSize;
+
+    /// @custom:spacer storageCost, dcfFactor, startTime, maxKvSize
+    /// @notice Spacer for backwards compatibility.
+    uint256[4] public kvSpacers;
+
     uint40 public lastKvIdx; // number of entries in the store
 
     struct PhyAddr {
@@ -34,6 +39,8 @@ contract DecentralizedKV is OwnableUpgradeable {
     mapping(bytes32 => PhyAddr) internal kvMap;
     /* index - skey, reverse lookup */
     mapping(uint256 => bytes32) internal idxMap;
+
+    // TODO: Reserve extra slots (to a total of 50?) in the storage layout for future upgrades
 
     constructor(uint256 _maxKvSize, uint256 _startTime, uint256 _storageCost, uint256 _dcfFactor) {
         maxKvSize = _maxKvSize;


### PR DESCRIPTION
https://github.com/ethstorage/storage-contracts-v1/pull/87 change the slot layout of the storage contract (you can find the deployed contract source code [here](https://sepolia.etherscan.io/address/0x6a019daa1c05fe89e274801d9f164316a1ad46bf#code)). 
To make the latest contract code is backwards compatible so that we can update the implementation of the deployed code, we use some placeholder slots to keep the same slot layout as before. 