### PR TITLE
Rename lastKvIdx to kvEntryCount and be compatible with earlier version

### DIFF
--- a/contracts/DecentralizedKV.sol
+++ b/contracts/DecentralizedKV.sol
@@ -6,7 +6,7 @@ import "./MerkleLib.sol";
 import "./BinaryRelated.sol";
 
 contract DecentralizedKV is OwnableUpgradeable {
-    event Remove(uint256 indexed kvIdx, uint256 indexed lastKvIdx);
+    event Remove(uint256 indexed kvIdx, uint256 indexed kvEntryCount);
 
     enum DecodeType {
         RawData,
@@ -24,7 +24,7 @@ contract DecentralizedKV is OwnableUpgradeable {
     /// @notice Spacer for backwards compatibility.
     uint256[4] public kvSpacers;
 
-    uint40 public lastKvIdx; // number of entries in the store
+    uint40 public kvEntryCount; // number of entries in the store
 
     struct PhyAddr {
         /* Internal address seeking */
@@ -52,7 +52,7 @@ contract DecentralizedKV is OwnableUpgradeable {
     function __init_KV(address _owner) public onlyInitializing {
         __Context_init();
         __Ownable_init(_owner);
-        lastKvIdx = 0;
+        kvEntryCount = 0;
     }
 
     function pow(uint256 fp, uint256 n) internal pure returns (uint256) {
@@ -95,9 +95,9 @@ contract DecentralizedKV is OwnableUpgradeable {
         if (paddr.hash == 0) {
             // append (require payment from sender)
             _prepareAppend();
-            paddr.kvIdx = lastKvIdx;
+            paddr.kvIdx = kvEntryCount;
             idxMap[paddr.kvIdx] = skey;
-            lastKvIdx = lastKvIdx + 1;
+            kvEntryCount = kvEntryCount + 1;
         }
         paddr.kvSize = uint24(length);
         paddr.hash = bytes24(dataHash);
@@ -184,5 +184,10 @@ contract DecentralizedKV is OwnableUpgradeable {
         }
 
         return res;
+    }
+
+    /// @notice This is for compatibility with earlier versions and can be removed in the future.
+    function lastKvIndex() public view returns (uint40) {
+        return kvEntryCount;
     }
 }

--- a/contracts/StorageContract.sol
+++ b/contracts/StorageContract.sol
@@ -100,8 +100,8 @@ abstract contract StorageContract is DecentralizedKV {
     function sendValue() public payable {}
 
     function _prepareAppendWithTimestamp(uint256 timestamp) internal {
-        uint256 totalEntries = lastKvIdx + 1; // include the one to be put
-        uint256 shardId = lastKvIdx >> shardEntryBits; // shard id of the new KV
+        uint256 totalEntries = kvEntryCount + 1; // include the one to be put
+        uint256 shardId = kvEntryCount >> shardEntryBits; // shard id of the new KV
         if ((totalEntries % (1 << shardEntryBits)) == 1) {
             // Open a new shard if the KV is the first one of the shard
             // and mark the shard is ready to mine.
@@ -117,8 +117,8 @@ abstract contract StorageContract is DecentralizedKV {
 
     // Upfront payment for the next insertion
     function upfrontPayment() public view virtual override returns (uint256) {
-        uint256 totalEntries = lastKvIdx + 1; // include the one to be put
-        uint256 shardId = lastKvIdx >> shardEntryBits; // shard id of the new KV
+        uint256 totalEntries = kvEntryCount + 1; // include the one to be put
+        uint256 shardId = kvEntryCount >> shardEntryBits; // shard id of the new KV
         // shard0 is already opened in constructor
         if ((totalEntries % (1 << shardEntryBits)) == 1 && shardId != 0) {
             // Open a new shard if the KV is the first one of the shard
@@ -180,13 +180,13 @@ abstract contract StorageContract is DecentralizedKV {
 
     function _miningReward(uint256 shardId, uint256 minedTs) internal view returns (bool, uint256, uint256) {
         MiningLib.MiningInfo storage info = infos[shardId];
-        uint256 lastShardIdx = lastKvIdx > 0 ? (lastKvIdx - 1) >> shardEntryBits : 0;
+        uint256 lastShardIdx = kvEntryCount > 0 ? (kvEntryCount - 1) >> shardEntryBits : 0;
         uint256 reward = 0;
         bool updatePrepaidTime = false;
         if (shardId < lastShardIdx) {
             reward = _paymentIn(storageCost << shardEntryBits, info.lastMineTime, minedTs);
         } else if (shardId == lastShardIdx) {
-            reward = _paymentIn(storageCost * (lastKvIdx % (1 << shardEntryBits)), info.lastMineTime, minedTs);
+            reward = _paymentIn(storageCost * (kvEntryCount % (1 << shardEntryBits)), info.lastMineTime, minedTs);
             // Additional prepaid for the last shard
             if (prepaidLastMineTime < minedTs) {
                 reward += _paymentIn(prepaidAmount, prepaidLastMineTime, minedTs);

--- a/contracts/TestDecentralizedKV.sol
+++ b/contracts/TestDecentralizedKV.sol
@@ -74,16 +74,16 @@ contract TestDecentralizedKV is DecentralizedKV {
         kvMap[skey] = PhyAddr({kvIdx: 0, kvSize: 0, hash: 0});
 
         // move last kv to current kv
-        bytes32 lastSkey = idxMap[lastKvIdx - 1];
+        bytes32 lastSkey = idxMap[kvEntryCount - 1];
         idxMap[kvIdx] = lastSkey;
         kvMap[lastSkey].kvIdx = kvIdx;
 
         // remove the last Kv
-        idxMap[lastKvIdx - 1] = 0x0;
-        lastKvIdx = lastKvIdx - 1;
+        idxMap[kvEntryCount - 1] = 0x0;
+        kvEntryCount = kvEntryCount - 1;
 
-        dataMap[kvIdx] = dataMap[lastKvIdx];
-        delete dataMap[lastKvIdx];
+        dataMap[kvIdx] = dataMap[kvEntryCount];
+        delete dataMap[kvEntryCount];
 
         payable(to).transfer(upfrontPayment());
     }


### PR DESCRIPTION
Note that es-node should also make the corresponding change to use kvEntryCount instead, as we will delete the lastKvIdx method in the future