### PR TITLE
Add putBlobs

### DIFF
--- a/contracts/DecentralizedKV.sol
+++ b/contracts/DecentralizedKV.sol
@@ -147,8 +147,6 @@ contract DecentralizedKV is OwnableUpgradeable {
         internal
         returns (uint256[] memory)
     {
-        require(_keys.length == _dataHashes.length && _keys.length == _lengths.length, "DecentralizedKV: invalid input");
-
         uint256[] memory res = new uint256[](_keys.length);
         uint256 batchPaymentSize = 0;
         for (uint256 i = 0; i < _keys.length; i++) {

--- a/contracts/DecentralizedKV.sol
+++ b/contracts/DecentralizedKV.sol
@@ -115,13 +115,7 @@ contract DecentralizedKV is OwnableUpgradeable {
     }
 
     /// @notice Checks before appending the key-value.
-    function _prepareAppend() internal virtual {
-        require(msg.value >= upfrontPayment(), "DecentralizedKV: not enough payment");
-    }
-
-    /// @notice Checks before batch appending the key-value.
-    /// @param _batchSize The size of the batch.
-    function _prepareBatchAppend(uint256 _batchSize) internal virtual {
+    function _prepareAppend(uint256 _batchSize) internal virtual {
         require(msg.value >= upfrontPayment() * _batchSize, "DecentralizedKV: not enough batch payment");
     }
 
@@ -137,7 +131,7 @@ contract DecentralizedKV is OwnableUpgradeable {
 
         if (paddr.hash == 0) {
             // append (require payment from sender)
-            _prepareAppend();
+            _prepareAppend(1);
             paddr.kvIdx = kvEntryCount;
             idxMap[paddr.kvIdx] = skey;
             kvEntryCount = kvEntryCount + 1;
@@ -175,7 +169,7 @@ contract DecentralizedKV is OwnableUpgradeable {
             res[i] = paddr.kvIdx;
         }
 
-        _prepareBatchAppend(batchPaymentSize);
+        _prepareAppend(batchPaymentSize);
 
         return res;
     }

--- a/contracts/EthStorageContract.sol
+++ b/contracts/EthStorageContract.sol
@@ -255,8 +255,10 @@ contract EthStorageContract is StorageContract, Decoder, ISemver {
         payable
         virtual
     {
-        require(_keys.length == _blobIdxs.length, "EthStorageContract: key length mismatch");
-        require(_keys.length == _lengths.length, "EthStorageContract: length length mismatch");
+        require(
+            _keys.length == _blobIdxs.length && _keys.length == _lengths.length,
+            "EthStorageContract: input length mismatch"
+        );
 
         bytes32[] memory dataHashes = new bytes32[](_blobIdxs.length);
         for (uint256 i = 0; i < _blobIdxs.length; i++) {

--- a/contracts/EthStorageContract.sol
+++ b/contracts/EthStorageContract.sol
@@ -241,9 +241,17 @@ contract EthStorageContract is StorageContract, Decoder, ISemver {
     function putBlob(bytes32 _key, uint256 _blobIdx, uint256 _length) public payable virtual {
         bytes32 dataHash = blobhash(_blobIdx);
         require(dataHash != 0, "EthStorageContract: failed to get blob hash");
-        uint256 kvIdx = _putInternal(_key, dataHash, _length);
 
-        emit PutBlob(kvIdx, _length, dataHash);
+        bytes32[] memory keys = new bytes32[](1);
+        keys[0] = _key;
+        bytes32[] memory dataHashes = new bytes32[](1);
+        dataHashes[0] = dataHash;
+        uint256[] memory lengths = new uint256[](1);
+        lengths[0] = _length;
+
+        uint256[] memory kvIndices = _putBatchInternal(keys, dataHashes, lengths);
+
+        emit PutBlob(kvIndices[0], _length, dataHash);
     }
 
     /// @notice Write multiple large values to KV store.

--- a/contracts/EthStorageContract.sol
+++ b/contracts/EthStorageContract.sol
@@ -38,12 +38,9 @@ contract EthStorageContract is StorageContract, Decoder, ISemver {
     event PutBlob(uint256 indexed kvIdx, uint256 indexed kvSize, bytes32 indexed dataHash);
 
     /// @notice Constructs the EthStorageContract contract.
-    constructor(
-        Config memory _config,
-        uint256 _startTime,
-        uint256 _storageCost,
-        uint256 _dcfFactor
-    ) StorageContract(_config, _startTime, _storageCost, _dcfFactor) {
+    constructor(Config memory _config, uint256 _startTime, uint256 _storageCost, uint256 _dcfFactor)
+        StorageContract(_config, _startTime, _storageCost, _dcfFactor)
+    {
         _disableInitializers();
     }
 
@@ -79,9 +76,7 @@ contract EthStorageContract is StorageContract, Decoder, ISemver {
             mstore(add(pointer, 0xa0), _m)
 
             // Call the precompiled contract 0x05 = bigModExp, reuse scratch to get the results
-            if iszero(staticcall(not(0), 0x05, pointer, 0xc0, 0x0, 0x20)) {
-                revert(0, 0)
-            }
+            if iszero(staticcall(not(0), 0x05, pointer, 0xc0, 0x0, 0x20)) { revert(0, 0) }
 
             result_ := mload(0x0)
 
@@ -95,25 +90,21 @@ contract EthStorageContract is StorageContract, Decoder, ISemver {
     /// @return versionedHash_ The versioned hash
     /// @return x_ The x coordinate
     /// @return y_ The y coordinate
-    function _pointEvaluation(
-        bytes memory _input
-    ) internal view returns (uint256 versionedHash_, uint256 x_, uint256 y_) {
+    function _pointEvaluation(bytes memory _input)
+        internal
+        view
+        returns (uint256 versionedHash_, uint256 x_, uint256 y_)
+    {
         assembly {
             versionedHash_ := mload(add(_input, 0x20))
             x_ := mload(add(_input, 0x40))
             y_ := mload(add(_input, 0x60))
 
             // Call the precompiled contract 0x0a = point evaluation, reuse scratch to get the results
-            if iszero(staticcall(not(0), 0x0a, add(_input, 0x20), 0xc0, 0x0, 0x40)) {
-                revert(0, 0)
-            }
+            if iszero(staticcall(not(0), 0x0a, add(_input, 0x20), 0xc0, 0x0, 0x40)) { revert(0, 0) }
             // Check the results
-            if iszero(eq(mload(0x0), FIELD_ELEMENTS_PER_BLOB)) {
-                revert(0, 0)
-            }
-            if iszero(eq(mload(0x20), MODULUS_BLS)) {
-                revert(0, 0)
-            }
+            if iszero(eq(mload(0x0), FIELD_ELEMENTS_PER_BLOB)) { revert(0, 0) }
+            if iszero(eq(mload(0x20), MODULUS_BLS)) { revert(0, 0) }
         }
     }
 
@@ -123,12 +114,11 @@ contract EthStorageContract is StorageContract, Decoder, ISemver {
     /// @param _sampleIdxInKv The sample index in the KV
     /// @param _mask The mask of the sample
     /// @return The result of the verification
-    function decodeSample(
-        Proof memory _proof,
-        uint256 _encodingKey,
-        uint256 _sampleIdxInKv,
-        uint256 _mask
-    ) public view returns (bool) {
+    function decodeSample(Proof memory _proof, uint256 _encodingKey, uint256 _sampleIdxInKv, uint256 _mask)
+        public
+        view
+        returns (bool)
+    {
         uint256 xBn254 = _modExp(RU_BN254, _sampleIdxInKv, MODULUS_BN254);
 
         uint256[] memory input = new uint256[](3);
@@ -145,12 +135,11 @@ contract EthStorageContract is StorageContract, Decoder, ISemver {
     /// @param _decodedData The decoded sample
     /// @param _peInput The point evaluation input
     /// @return The result of the check
-    function checkInclusive(
-        bytes32 _dataHash,
-        uint256 _sampleIdxInKv,
-        uint256 _decodedData,
-        bytes memory _peInput
-    ) public view returns (bool) {
+    function checkInclusive(bytes32 _dataHash, uint256 _sampleIdxInKv, uint256 _decodedData, bytes memory _peInput)
+        public
+        view
+        returns (bool)
+    {
         if (_dataHash == 0x0) {
             return _decodedData == 0;
         }
@@ -200,7 +189,11 @@ contract EthStorageContract is StorageContract, Decoder, ISemver {
     /// @param _hash0 The hash0
     /// @return The key index contains the sample
     /// @return The sample index in the key
-    function getSampleIdx(uint256 _rows, uint256 _startShardId, bytes32 _hash0) public view returns (uint256, uint256) {
+    function getSampleIdx(uint256 _rows, uint256 _startShardId, bytes32 _hash0)
+        public
+        view
+        returns (uint256, uint256)
+    {
         uint256 parent = uint256(_hash0) % _rows;
         uint256 sampleIdx = parent + (_startShardId << (SHARD_ENTRY_BITS + SAMPLE_LEN_BITS));
         uint256 kvIdx = sampleIdx >> SAMPLE_LEN_BITS;
@@ -231,13 +224,7 @@ contract EthStorageContract is StorageContract, Decoder, ISemver {
 
             require(
                 decodeAndCheckInclusive(
-                    kvIdx,
-                    sampleIdxInKv,
-                    _miner,
-                    _encodedSamples[i],
-                    _masks[i],
-                    _inclusiveProofs[i],
-                    _decodeProof[i]
+                    kvIdx, sampleIdxInKv, _miner, _encodedSamples[i], _masks[i], _inclusiveProofs[i], _decodeProof[i]
                 ),
                 "EthStorageContract: invalid samples"
             );
@@ -257,5 +244,30 @@ contract EthStorageContract is StorageContract, Decoder, ISemver {
         uint256 kvIdx = _putInternal(_key, dataHash, _length);
 
         emit PutBlob(kvIdx, _length, dataHash);
+    }
+
+    /// @notice Write multiple large values to KV store.
+    /// @param _keys The keys of the KV pairs
+    /// @param _blobIdxs The indexes of the blobs
+    /// @param _lengths The lengths of the blobs
+    function putBlobs(bytes32[] memory _keys, uint256[] memory _blobIdxs, uint256[] memory _lengths)
+        public
+        payable
+        virtual
+    {
+        require(_keys.length == _blobIdxs.length, "EthStorageContract: key length mismatch");
+        require(_keys.length == _lengths.length, "EthStorageContract: length length mismatch");
+
+        bytes32[] memory dataHashes = new bytes32[](_blobIdxs.length);
+        for (uint256 i = 0; i < _blobIdxs.length; i++) {
+            dataHashes[i] = blobhash(_blobIdxs[i]);
+            require(dataHashes[i] != 0, "EthStorageContract: failed to get blob hash");
+        }
+
+        uint256[] memory kvIdxs = _putBatchInternal(_keys, dataHashes, _lengths);
+
+        for (uint256 i = 0; i < _blobIdxs.length; i++) {
+            emit PutBlob(kvIdxs[i], _lengths[i], dataHashes[i]);
+        }
     }
 }

--- a/contracts/StorageContract.sol
+++ b/contracts/StorageContract.sol
@@ -145,6 +145,26 @@ abstract contract StorageContract is DecentralizedKV {
     /// @notice People can sent ETH to the contract.
     function sendValue() public payable {}
 
+    /// @notice Checks the payment using the last mine time.
+    function _prepareAppendWithTimestamp(uint256 _timestamp, uint256 _batchSize) internal {
+        uint256 totalEntries = kvEntryCount + 1; // include the one to be put
+        uint256 shardId = kvEntryCount >> SHARD_ENTRY_BITS; // shard id of the new KV
+        if ((totalEntries % (1 << SHARD_ENTRY_BITS)) == 1) {
+            // Open a new shard if the KV is the first one of the shard
+            // and mark the shard is ready to mine.
+            // (TODO): Setup shard difficulty as current difficulty / factor?
+            if (shardId != 0) {
+                // shard0 is already opened in constructor
+                infos[shardId].lastMineTime = _timestamp;
+            }
+        }
+
+        require(
+            msg.value >= _upfrontPayment(infos[shardId].lastMineTime) * _batchSize,
+            "StorageContract: not enough batch payment"
+        );
+    }
+
     /// @notice Upfront payment for the next insertion
     function upfrontPayment() public view virtual override returns (uint256) {
         uint256 totalEntries = kvEntryCount + 1; // include the one to be put
@@ -158,6 +178,11 @@ abstract contract StorageContract is DecentralizedKV {
         } else {
             return _upfrontPayment(infos[shardId].lastMineTime);
         }
+    }
+
+    /// @inheritdoc DecentralizedKV
+    function _prepareAppend(uint256 _batchSize) internal virtual override {
+        return _prepareAppendWithTimestamp(block.timestamp, _batchSize);
     }
 
     /// @notice Verify the samples of the BLOBs by the miner (storage provider) including

--- a/contracts/test/EthStorageContractTest.t.sol
+++ b/contracts/test/EthStorageContractTest.t.sol
@@ -36,7 +36,7 @@ contract EthStorageContractTest is Test {
         uint256 insufficientCost = storageContract.upfrontPayment() - 1;
 
         // Expect the specific revert reason from _prepareAppend due to insufficient msg.value
-        vm.expectRevert("DecentralizedKV: not enough payment");
+        vm.expectRevert("StorageContract: not enough batch payment");
         storageContract.putBlob{value: insufficientCost}(key, blobIdx, length);
 
         // Enough storage cost
@@ -71,7 +71,7 @@ contract EthStorageContractTest is Test {
         uint256 insufficientCost = storageContract.upfrontPayment();
 
         // Expect the specific revert reason from _prepareBatchAppend due to insufficient msg.value
-        vm.expectRevert("DecentralizedKV: not enough batch payment");
+        vm.expectRevert("StorageContract: not enough batch payment");
         storageContract.putBlobs{value: insufficientCost}(keys, blobIdxs, lengths);
 
         // Enough storage cost

--- a/contracts/test/EthStorageContractTest.t.sol
+++ b/contracts/test/EthStorageContractTest.t.sol
@@ -1,0 +1,73 @@
+// SPDX-License-Identifier: UNLICENSED
+pragma solidity ^0.8.19;
+
+import "./TestEthStorageContract.sol";
+import "forge-std/Test.sol";
+import "forge-std/Vm.sol";
+import "forge-std/console.sol";
+import "@openzeppelin/contracts/proxy/transparent/TransparentUpgradeableProxy.sol";
+
+contract EthStorageContractTest is Test {
+    uint256 constant STORAGE_COST = 1000;
+    uint256 constant SHARD_SIZE_BITS = 19;
+    uint256 constant MAX_KV_SIZE = 17;
+    uint256 constant PREPAID_AMOUNT = 2 * STORAGE_COST;
+
+    TestEthStorageContract storageContract;
+    address owner = address(0x1);
+
+    function setUp() public {
+        TestEthStorageContract imp = new TestEthStorageContract(
+            StorageContract.Config(MAX_KV_SIZE, SHARD_SIZE_BITS, 2, 0, 0, 0), 0, STORAGE_COST, 0
+        );
+        bytes memory data = abi.encodeWithSelector(
+            storageContract.initialize.selector, 0, PREPAID_AMOUNT, 0, address(0x1), address(0x1)
+        );
+        TransparentUpgradeableProxy proxy = new TransparentUpgradeableProxy(address(imp), owner, data);
+
+        storageContract = TestEthStorageContract(address(proxy));
+    }
+
+    function testPutBlobs() public {
+        bytes32[] memory keys = new bytes32[](2);
+        keys[0] = bytes32(uint256(0));
+        keys[1] = bytes32(uint256(1));
+        uint256[] memory blobIdxs = new uint256[](2);
+        blobIdxs[0] = 0;
+        blobIdxs[1] = 0;
+        uint256[] memory lengths = new uint256[](2);
+        lengths[0] = 10;
+        lengths[1] = 20;
+
+        uint256 insufficientCost = storageContract.upfrontPayment();
+
+        // Expect the specific revert reason from _prepareBatchAppend due to insufficient msg.value
+        vm.expectRevert("DecentralizedKV: not enough batch payment");
+        storageContract.putBlobs{value: insufficientCost}(keys, blobIdxs, lengths);
+
+        // Enough storage cost
+        uint256 sufficientCost = 2 * storageContract.upfrontPayment();
+        storageContract.putBlobs{value: sufficientCost}(keys, blobIdxs, lengths);
+
+        assertEq(storageContract.kvEntryCount(), 2);
+        assertEq(storageContract.hash(keys[0]), bytes32(uint256(1 << 8 * 8)));
+        assertEq(storageContract.hash(keys[1]), bytes32(uint256(2 << 8 * 8)));
+        assertEq(storageContract.size(keys[0]), 10);
+        assertEq(storageContract.size(keys[1]), 20);
+
+        // Still pass two keys, but only appending a new key-value
+        lengths[0] = 30;
+        keys[1] = bytes32(uint256(2));
+        lengths[1] = 30;
+
+        sufficientCost = storageContract.upfrontPayment();
+        storageContract.putBlobs{value: sufficientCost}(keys, blobIdxs, lengths);
+        assertEq(storageContract.kvEntryCount(), 3);
+        assertEq(storageContract.hash(bytes32(uint256(0))), bytes32(uint256(1 << 8 * 8)));
+        assertEq(storageContract.hash(bytes32(uint256(1))), bytes32(uint256(2 << 8 * 8)));
+        assertEq(storageContract.hash(bytes32(uint256(2))), bytes32(uint256(2 << 8 * 8)));
+        assertEq(storageContract.size(bytes32(uint256(0))), 30);
+        assertEq(storageContract.size(bytes32(uint256(1))), 20);
+        assertEq(storageContract.size(bytes32(uint256(2))), 30);
+    }
+}

--- a/contracts/test/TestDecentralizedKV.sol
+++ b/contracts/test/TestDecentralizedKV.sol
@@ -8,12 +8,9 @@ contract TestDecentralizedKV is DecentralizedKV {
 
     mapping(uint256 => bytes) internal dataMap;
 
-    constructor(
-        uint256 _maxKvSize,
-        uint256 _startTime,
-        uint256 _storageCost,
-        uint256 _dcfFactor
-    ) DecentralizedKV(_maxKvSize, _startTime, _storageCost, _dcfFactor) {}
+    constructor(uint256 _maxKvSize, uint256 _startTime, uint256 _storageCost, uint256 _dcfFactor)
+        DecentralizedKV(_maxKvSize, _startTime, _storageCost, _dcfFactor)
+    {}
 
     function initialize(address owner) public initializer {
         __init_KV(owner);
@@ -30,16 +27,24 @@ contract TestDecentralizedKV is DecentralizedKV {
 
     function put(bytes32 key, bytes memory data) public payable {
         bytes32 dataHash = keccak256(data);
-        uint256 kvIdx = _putInternal(key, dataHash, data.length);
-        dataMap[kvIdx] = data;
+
+        bytes32[] memory keys = new bytes32[](1);
+        keys[0] = key;
+        bytes32[] memory dataHashes = new bytes32[](1);
+        dataHashes[0] = dataHash;
+        uint256[] memory lengths = new uint256[](1);
+        lengths[0] = data.length;
+
+        uint256[] memory kvIndices = _putBatchInternal(keys, dataHashes, lengths);
+        dataMap[kvIndices[0]] = data;
     }
 
-    function get(
-        bytes32 key,
-        DecodeType decodeType,
-        uint256 off,
-        uint256 len
-    ) public view override returns (bytes memory) {
+    function get(bytes32 key, DecodeType decodeType, uint256 off, uint256 len)
+        public
+        view
+        override
+        returns (bytes memory)
+    {
         if (len == 0) {
             return new bytes(0);
         }

--- a/contracts/test/TestEthStorageContract.sol
+++ b/contracts/test/TestEthStorageContract.sol
@@ -23,16 +23,33 @@ contract TestEthStorageContract is EthStorageContract {
     }
 
     function put(bytes32 key, bytes memory data) public payable {
-        bytes32 dataHash = MerkleLib.merkleRootWithMinTree(data, 32); // TODO: 64-bytes should be more efficient.
-        _putInternal(key, dataHash, data.length);
+        bytes32 dataHash = MerkleLib.merkleRootWithMinTree(data, 32);
+
+        bytes32[] memory keys = new bytes32[](1);
+        keys[0] = key;
+        bytes32[] memory dataHashes = new bytes32[](1);
+        dataHashes[0] = dataHash;
+        uint256[] memory lengths = new uint256[](1);
+        lengths[0] = data.length;
+
+        // TODO: 64-bytes should be more efficient.
+        _putBatchInternal(keys, dataHashes, lengths);
     }
 
     function putBlob(bytes32 _key, uint256 _blobIdx, uint256 _length) public payable override {
         bytes32 dataHash = bytes32(uint256(1 << 8 * 8));
         require(dataHash != 0, "EthStorageContract: failed to get blob hash");
-        uint256 kvIdx = _putInternal(_key, dataHash, _length);
 
-        emit PutBlob(kvIdx, _length, dataHash);
+        bytes32[] memory keys = new bytes32[](1);
+        keys[0] = _key;
+        bytes32[] memory dataHashes = new bytes32[](1);
+        dataHashes[0] = dataHash;
+        uint256[] memory lengths = new uint256[](1);
+        lengths[0] = _length;
+
+        uint256[] memory kvIndices = _putBatchInternal(keys, dataHashes, lengths);
+
+        emit PutBlob(kvIndices[0], _length, dataHash);
     }
 
     function putBlobs(bytes32[] memory _keys, uint256[] memory _blobIdxs, uint256[] memory _lengths)

--- a/contracts/test/TestEthStorageContract.sol
+++ b/contracts/test/TestEthStorageContract.sol
@@ -27,6 +27,14 @@ contract TestEthStorageContract is EthStorageContract {
         _putInternal(key, dataHash, data.length);
     }
 
+    function putBlob(bytes32 _key, uint256 _blobIdx, uint256 _length) public payable override {
+        bytes32 dataHash = bytes32(uint256(1 << 8 * 8));
+        require(dataHash != 0, "EthStorageContract: failed to get blob hash");
+        uint256 kvIdx = _putInternal(_key, dataHash, _length);
+
+        emit PutBlob(kvIdx, _length, dataHash);
+    }
+
     function putBlobs(bytes32[] memory _keys, uint256[] memory _blobIdxs, uint256[] memory _lengths)
         public
         payable

--- a/test/decentralized-kv-test.js
+++ b/test/decentralized-kv-test.js
@@ -55,12 +55,12 @@ describe("DecentralizedKV Test", function () {
     await kv.initialize(ownerAddr);
 
     expect(await kv.upfrontPayment()).to.equal("1000000000000000000");
-    await expect(kv.put(key1, "0x11223344")).to.be.revertedWith("DecentralizedKV: not enough payment");
+    await expect(kv.put(key1, "0x11223344")).to.be.revertedWith("DecentralizedKV: not enough batch payment");
     await expect(
       kv.put(key1, "0x11223344", {
         value: "900000000000000000",
       })
-    ).to.be.revertedWith("DecentralizedKV: not enough payment");
+    ).to.be.revertedWith("DecentralizedKV: not enough batch payment");
     await kv.put(key1, "0x11223344", {
       value: ethers.utils.parseEther("1.0"),
     });
@@ -91,12 +91,12 @@ describe("DecentralizedKV Test", function () {
     await kv.initialize(ownerAddr);
 
     expect(await kv.upfrontPayment()).to.equal("1000000000000000000");
-    await expect(kv.put(key1, "0x11223344")).to.be.revertedWith("DecentralizedKV: not enough payment");
+    await expect(kv.put(key1, "0x11223344")).to.be.revertedWith("DecentralizedKV: not enough batch payment");
     await expect(
       kv.put(key1, "0x11223344", {
         value: "900000000000000000",
       })
-    ).to.be.revertedWith("DecentralizedKV: not enough payment");
+    ).to.be.revertedWith("DecentralizedKV: not enough batch payment");
     await kv.put(key1, "0x11223344", {
       value: ethers.utils.parseEther("1.0"),
     });


### PR DESCRIPTION
Fix https://github.com/ethstorage/storage-contracts-v1/issues/17.
Additionally, since `_prepareAppendWithTimestamp` has similar logic to `upfrontPayment` in `StorageContract`, we can delete the overriding `_prepareAppend`. The superclass `DecentralizedKV` is currently using the `upfrontPayment` for updated logic