### PR TITLE
Change the shard size in the deployL2-it.js to 1GB to support test multi-shards in the integration test.

### DIFF
--- a/scripts/deployL2-it.js
+++ b/scripts/deployL2-it.js
@@ -53,7 +53,7 @@ async function deployContract() {
 
   const data = implContract.interface.encodeFunctionData("initialize", [
     1572864, // minimumDiff 0.1 * 180 (3 minutes) * 1024 * 1024 / 12 = 1572864 for 0.1 replicas that can have 1M IOs in one epoch
-    24576000000000000000n, // prepaidAmount - 50% * 2^32 / 131072 * 1500000Gwei, it also means 3145 ETH for half of the shard
+    6144000000000000000n, // prepaidAmount - 50% * 2^30 / 131072 * 1500000Gwei, it also means 3145 ETH for half of the shard
     1048576, // nonceLimit 1024 * 1024 = 1M samples and finish sampling in 1.3s with IO rate 6144 MB/s: 4k * 2(random checks) / 6144 = 1.3s
     treasuryAddress, // treasury
     ownerAddress,

--- a/scripts/deployL2-it.js
+++ b/scripts/deployL2-it.js
@@ -12,7 +12,7 @@ const gasPrice = null;
 
 const config = [
   17, // maxKvSizeBits, 131072
-  32, // shardSizeBits ~ 4G
+  30, // shardSizeBits ~ 1G
   2, // randomChecks
   7200, // cutoff = 2/3 * target internal (3 hours), 3 * 3600 * 2/3
   32, // diffAdjDivisor


### PR DESCRIPTION
Change the shard size in the deployL2-it.js to 1GB to support test multi-shards in the integration test.

As we want to upload more than 1 shard of data and assume that the second shard already has about 30% of the data: 
If the shard size is 1G (8192 blobs), then we can upload 10,800 blobs (8192 blobs in shard 0 and 2608 blobs in shard 1 to make it easy to calculate) using writeBlobs with batch size 6. Then, we need to upload 1800 times, which would take at least 3600s = 1h.
If the shard size is 4G (32,768 blobs), then we can upload 10,800 * 4 = 43,200 blobs (same data coverage in shard 1) using writeBlobs with a batch size of 6, then we need to upload 7,200 times which would take at least  14,400s = 4h. 

Considering that not every transaction can be included in the block, it may take more than 12 hours, so change the value to 1G.

