### PR TITLE
Track prepaid amount and withdraw treasury

### DIFF
--- a/contracts/StorageContract.sol
+++ b/contracts/StorageContract.sol
@@ -390,8 +390,9 @@ abstract contract StorageContract is DecentralizedKV {
 
     /// @notice Withdraw treasury fund
     function withdraw(uint256 _amount) public {
-        require(totalPrepaidAmount >= prepaidAmount + _amount, "Not enough prepaid amount");
+        require(totalPrepaidAmount >= prepaidAmount + _amount, "StorageContract: not enough prepaid amount");
         totalPrepaidAmount -= _amount;
+        require(address(this).balance >= _amount, "StorageContract: not enough balance");
         payable(treasury).transfer(_amount);
     }
 

--- a/contracts/StorageContract.sol
+++ b/contracts/StorageContract.sol
@@ -390,7 +390,7 @@ abstract contract StorageContract is DecentralizedKV {
 
     /// @notice Withdraw treasury fund
     function withdraw(uint256 _amount) public {
-        require(totalPrepaidAmount + _amount >= prepaidAmount, "Not enough prepaid amount");
+        require(totalPrepaidAmount >= prepaidAmount + _amount, "Not enough prepaid amount");
         totalPrepaidAmount -= _amount;
         payable(treasury).transfer(_amount);
     }

--- a/contracts/StorageContract.sol
+++ b/contracts/StorageContract.sol
@@ -256,6 +256,7 @@ abstract contract StorageContract is DecentralizedKV {
     /// @param _shardId  The shard id.
     /// @param _minedTs  The mined timestamp.
     /// @return updatePrepaidTime Whether to update the prepaid time.
+    /// @return prepaidAmountSaved The capped part of prepaid amount.
     /// @return treasuryReward    The treasury reward.
     /// @return minerReward       The miner reward.
     function _miningReward(uint256 _shardId, uint256 _minedTs)

--- a/contracts/StorageContract.sol
+++ b/contracts/StorageContract.sol
@@ -281,20 +281,14 @@ abstract contract StorageContract is DecentralizedKV, ReentrancyGuardTransient {
             reward = _paymentIn(STORAGE_COST * (kvEntryCount % (1 << SHARD_ENTRY_BITS)), info.lastMineTime, _minedTs);
             // Additional prepaid for the last shard
             if (prepaidLastMineTime < _minedTs) {
-                uint256 prepaidAmountCap =
-                    STORAGE_COST * ((1 << SHARD_ENTRY_BITS) - kvEntryCount % (1 << SHARD_ENTRY_BITS));
-                if (prepaidAmountCap > prepaidAmount) {
-if (prepaidLastMineTime < _minedTs) {
-    fullReward = _paymentIn(STORAGE_COST << SHARD_ENTRY_BITS, info.lastMineTime, _minedTs);
-    prepaidAmountIn = _paymentIn(prepaidAmount, prepaidLastMineTime, _minedTs);
-    if (prepaidAmountIn > fullReward - reward) {
-        prepaidAmountIn = fullReward - reward;
-    }
-}
-                        - _paymentIn(prepaidAmount, prepaidLastMineTime, _minedTs);
-                    prepaidAmountCap = prepaidAmount;
+                uint256 fullReward = _paymentIn(STORAGE_COST << SHARD_ENTRY_BITS, info.lastMineTime, _minedTs);
+                uint256 prepaidAmountIn = _paymentIn(prepaidAmount, prepaidLastMineTime, _minedTs);
+                uint256 rewardCap = fullReward - reward;
+                if (prepaidAmountIn > rewardCap) {
+                    prepaidAmountSaved = prepaidAmountIn - rewardCap;
+                    prepaidAmountIn = rewardCap;
                 }
-                reward += _paymentIn(prepaidAmountCap, prepaidLastMineTime, _minedTs);
+                reward += prepaidAmountIn;
                 updatePrepaidTime = true;
             }
         }

--- a/contracts/StorageContract.sol
+++ b/contracts/StorageContract.sol
@@ -82,7 +82,7 @@ abstract contract StorageContract is DecentralizedKV {
     uint256 public prepaidLastMineTime;
 
     /// @notice Fund tracker for prepaid
-    uint256 public totalPrepaidAmount;
+    uint256 public accPrepaidAmount;
 
     // TODO: Reserve extra slots (to a total of 50?) in the storage layout for future upgrades
 
@@ -147,7 +147,7 @@ abstract contract StorageContract is DecentralizedKV {
 
     /// @notice People can sent ETH to the contract.
     function sendValue() public payable {
-        totalPrepaidAmount += msg.value;
+        accPrepaidAmount += msg.value;
     }
 
     /// @notice Upfront payment for the next insertion
@@ -241,9 +241,9 @@ abstract contract StorageContract is DecentralizedKV {
             prepaidLastMineTime = _minedTs;
         }
         if (prepaidAmountSaved > 0) {
-            totalPrepaidAmount += prepaidAmountSaved;
+            accPrepaidAmount += prepaidAmountSaved;
         }
-        totalPrepaidAmount += treasuryReward;
+        accPrepaidAmount += treasuryReward;
         // Update mining info.
         MiningLib.update(infos[_shardId], _minedTs, _diff);
 
@@ -391,8 +391,8 @@ abstract contract StorageContract is DecentralizedKV {
 
     /// @notice Withdraw treasury fund
     function withdraw(uint256 _amount) public {
-        require(totalPrepaidAmount >= prepaidAmount + _amount, "StorageContract: not enough prepaid amount");
-        totalPrepaidAmount -= _amount;
+        require(accPrepaidAmount >= prepaidAmount + _amount, "StorageContract: not enough prepaid amount");
+        accPrepaidAmount -= _amount;
         require(address(this).balance >= _amount, "StorageContract: not enough balance");
         payable(treasury).transfer(_amount);
     }

--- a/contracts/StorageContract.sol
+++ b/contracts/StorageContract.sol
@@ -284,7 +284,13 @@ abstract contract StorageContract is DecentralizedKV, ReentrancyGuardTransient {
                 uint256 prepaidAmountCap =
                     STORAGE_COST * ((1 << SHARD_ENTRY_BITS) - kvEntryCount % (1 << SHARD_ENTRY_BITS));
                 if (prepaidAmountCap > prepaidAmount) {
-                    prepaidAmountSaved = _paymentIn(prepaidAmountCap, prepaidLastMineTime, _minedTs)
+if (prepaidLastMineTime < _minedTs) {
+    fullReward = _paymentIn(STORAGE_COST << SHARD_ENTRY_BITS, info.lastMineTime, _minedTs);
+    prepaidAmountIn = _paymentIn(prepaidAmount, prepaidLastMineTime, _minedTs);
+    if (prepaidAmountIn > fullReward - reward) {
+        prepaidAmountIn = fullReward - reward;
+    }
+}
                         - _paymentIn(prepaidAmount, prepaidLastMineTime, _minedTs);
                     prepaidAmountCap = prepaidAmount;
                 }

--- a/contracts/StorageContract.sol
+++ b/contracts/StorageContract.sol
@@ -242,14 +242,11 @@ abstract contract StorageContract is DecentralizedKV, ReentrancyGuardTransient {
         if (updatePrepaidTime) {
             prepaidLastMineTime = _minedTs;
         }
-        if (prepaidAmountSaved > 0) {
-            accPrepaidAmount += prepaidAmountSaved;
-        }
-        accPrepaidAmount += treasuryReward;
+        accPrepaidAmount += prepaidAmountSaved + treasuryReward;
         // Update mining info.
         MiningLib.update(infos[_shardId], _minedTs, _diff);
 
-        require(treasuryReward + minerReward <= address(this).balance, "StorageContract: not enough balance");
+        require(minerReward <= address(this).balance, "StorageContract: not enough balance");
         // Actually `transfer` is limited by the amount of gas allocated, which is not sufficient to enable reentrancy attacks.
         // However, this behavior may restrict the extensibility of scenarios where the receiver is a contract that requires
         // additional gas for its fallback functions of proper operations.

--- a/contracts/test/StorageContractTest.t.sol
+++ b/contracts/test/StorageContractTest.t.sol
@@ -97,7 +97,7 @@ contract StorageContractTest is Test {
 
         storageContract.sendValue{value: valueToSent}();
 
-        vm.expectRevert("Not enough prepaid amount");
+        vm.expectRevert("StorageContract: not enough prepaid amount");
         storageContract.withdraw(withdrawAmount);
     }
 }

--- a/contracts/test/StorageContractTest.t.sol
+++ b/contracts/test/StorageContractTest.t.sol
@@ -22,22 +22,22 @@ contract StorageContractTest is Test {
 
     function testMiningReward() public {
         // no key-value stored on EthStorage, only use prepaid amount as the reward
-        (,, uint256 reward) = storageContract.miningRewards(0, 1);
+        (,,, uint256 reward) = storageContract.miningRewards(0, 1);
         assertEq(reward, storageContract.paymentIn(PREPAID_AMOUNT, 0, 1));
 
         // 1 key-value stored on EthStorage
         storageContract.setKvEntryCount(1);
-        (,, reward) = storageContract.miningRewards(0, 1);
+        (,,, reward) = storageContract.miningRewards(0, 1);
         assertEq(reward, storageContract.paymentIn(PREPAID_AMOUNT + STORAGE_COST * 1, 0, 1));
 
         // 2 key-value stored on EthStorage
         storageContract.setKvEntryCount(2);
-        (,, reward) = storageContract.miningRewards(0, 1);
+        (,,, reward) = storageContract.miningRewards(0, 1);
         assertEq(reward, storageContract.paymentIn(PREPAID_AMOUNT + STORAGE_COST * 2, 0, 1));
 
         // 3 key-value stored on EthStorage, but the reward is capped with 4 * STORAGE_COST
         storageContract.setKvEntryCount(3);
-        (,, reward) = storageContract.miningRewards(0, 1);
+        (,,, reward) = storageContract.miningRewards(0, 1);
         assertEq(reward, storageContract.paymentIn(PREPAID_AMOUNT + STORAGE_COST * 2, 0, 1));
     }
 }

--- a/contracts/test/StorageContractTest.t.sol
+++ b/contracts/test/StorageContractTest.t.sol
@@ -55,10 +55,10 @@ contract StorageContractTest is Test {
         uint256 withdrawAmount = 800;
 
         storageContract.sendValue{value: valueToSent}();
-        assertEq(storageContract.totalPrepaidAmount(), valueToSent);
+        assertEq(storageContract.accPrepaidAmount(), valueToSent);
 
         storageContract.withdraw(withdrawAmount);
-        assertEq(storageContract.totalPrepaidAmount(), valueToSent - withdrawAmount);
+        assertEq(storageContract.accPrepaidAmount(), valueToSent - withdrawAmount);
         assertEq(storageContract.treasury().balance, withdrawAmount);
     }
 
@@ -83,10 +83,10 @@ contract StorageContractTest is Test {
 
         storageContract.rewardMiner(0, vm.addr(2), mineTs, 1);
         uint256 totalPrepaid = valueToSent + treasureReward + prepaidAmountSaved;
-        assertEq(storageContract.totalPrepaidAmount(), totalPrepaid);
+        assertEq(storageContract.accPrepaidAmount(), totalPrepaid);
 
         storageContract.withdraw(withdrawAmount);
-        assertEq(storageContract.totalPrepaidAmount(), totalPrepaid - withdrawAmount);
+        assertEq(storageContract.accPrepaidAmount(), totalPrepaid - withdrawAmount);
         assertEq(storageContract.treasury().balance, withdrawAmount);
         assertEq(address(storageContract).balance, valueToSent - minerReward - withdrawAmount);
     }

--- a/contracts/test/TestStorageContract.sol
+++ b/contracts/test/TestStorageContract.sol
@@ -41,4 +41,8 @@ contract TestStorageContract is StorageContract {
     function miningRewards(uint256 _shardId, uint256 _minedTs) public view returns (bool, uint256, uint256, uint256) {
         return _miningReward(_shardId, _minedTs);
     }
+
+    function rewardMiner(uint256 _shardId, address _miner, uint256 _minedTs, uint256 _diff) public {
+        return _rewardMiner(_shardId, _miner, _minedTs, _diff);
+    }
 }

--- a/contracts/test/TestStorageContract.sol
+++ b/contracts/test/TestStorageContract.sol
@@ -38,7 +38,7 @@ contract TestStorageContract is StorageContract {
         return _paymentIn(_x, _fromTs, _toTs);
     }
 
-    function miningRewards(uint256 _shardId, uint256 _minedTs) public view returns (bool, uint256, uint256) {
+    function miningRewards(uint256 _shardId, uint256 _minedTs) public view returns (bool, uint256, uint256, uint256) {
         return _miningReward(_shardId, _minedTs);
     }
 }


### PR DESCRIPTION
Addressing https://github.com/ethstorage/storage-contracts-v1/issues/54.

As discussed offline, we need a variable to track the total prepaid amount, and a withdrawal method to transfer the extra treasury as much as the fund meets the prepaid requirement.

The unit tests cover the case where the prepaid amount is capped when rewarding miners, which should be part of treasury.