### PR TITLE
Update cost

### DIFF
--- a/contracts/DecentralizedKV.sol
+++ b/contracts/DecentralizedKV.sol
@@ -283,4 +283,9 @@ contract DecentralizedKV is OwnableUpgradeable {
     function maxKvSize() public view returns (uint256) {
         return MAX_KV_SIZE;
     }
+
+    /// @notice Getter for UPDATE_COST
+    function updateCost() public view returns (uint256) {
+        return UPDATE_COST;
+    }
 }

--- a/contracts/DecentralizedKV.sol
+++ b/contracts/DecentralizedKV.sol
@@ -119,7 +119,10 @@ contract DecentralizedKV is OwnableUpgradeable {
 
     /// @notice Checks while appending the key-value.
     function _checkBatch(uint256 _batchSize, uint256 _updateSize) internal virtual {
-        require(msg.value >= upfrontPayment() + UPDATE_COST * _updateSize, "DecentralizedKV: not enough batch payment");
+        require(
+            msg.value >= upfrontPayment() * _batchSize + UPDATE_COST * _updateSize,
+            "DecentralizedKV: not enough batch payment"
+        );
     }
 
     /// @notice Called by public putBlob and putBlobs methods.

--- a/contracts/StorageContract.sol
+++ b/contracts/StorageContract.sol
@@ -173,10 +173,10 @@ abstract contract StorageContract is DecentralizedKV {
     }
 
     /// @inheritdoc DecentralizedKV
-    function _checkAppend(uint256 _batchSize) internal virtual override {
+    function _checkBatch(uint256 _batchSize, uint256 _updateSize) internal virtual override {
         uint256 kvEntryCountPrev = kvEntryCount - _batchSize; // kvEntryCount already increased
         uint256 totalPayment = _upfrontPaymentInBatch(kvEntryCountPrev, _batchSize);
-        require(msg.value >= totalPayment, "StorageContract: not enough batch payment");
+        require(msg.value >= totalPayment + _updateSize * UPDATE_COST, "StorageContract: not enough batch payment");
 
         uint256 shardId = kvEntryCount >> SHARD_ENTRY_BITS; // shard id after the batch
         if (shardId > (kvEntryCountPrev >> SHARD_ENTRY_BITS)) {
@@ -326,6 +326,11 @@ abstract contract StorageContract is DecentralizedKV {
     /// @notice Set the treasury address.
     function setMinimumDiff(uint256 _minimumDiff) public onlyOwner {
         minimumDiff = _minimumDiff;
+    }
+
+    /// @notice Set the cost to update a kv.
+    function setUpdateCost(uint256 _updateCost) public onlyOwner {
+        UPDATE_COST = _updateCost;
     }
 
     /// @notice On-chain verification of storage proof of sufficient sampling.

--- a/contracts/StorageContract.sol
+++ b/contracts/StorageContract.sol
@@ -328,11 +328,6 @@ abstract contract StorageContract is DecentralizedKV {
         minimumDiff = _minimumDiff;
     }
 
-    /// @notice Set the cost to update a kv.
-    function setUpdateCost(uint256 _updateCost) public onlyOwner {
-        UPDATE_COST = _updateCost;
-    }
-
     /// @notice On-chain verification of storage proof of sufficient sampling.
     ///         On-chain verifier will go same routine as off-chain data host, will check the encoded samples by decoding
     ///         to decoded one. The decoded samples will be used to perform inclusive check with on-chain datahashes.

--- a/contracts/test/EthStorageContractTest.t.sol
+++ b/contracts/test/EthStorageContractTest.t.sol
@@ -89,7 +89,7 @@ contract EthStorageContractTest is Test {
         keys[1] = bytes32(uint256(2));
         lengths[1] = 30;
 
-        sufficientCost = storageContract.upfrontPayment();
+        sufficientCost = storageContract.upfrontPayment() + 2 * storageContract.updateCost();
         storageContract.putBlobs{value: sufficientCost}(keys, blobIdxs, lengths);
         assertEq(storageContract.kvEntryCount(), 3);
         assertEq(storageContract.hash(bytes32(uint256(0))), bytes32(uint256(1 << 8 * 8)));

--- a/contracts/test/TestDecentralizedKV.sol
+++ b/contracts/test/TestDecentralizedKV.sol
@@ -39,6 +39,22 @@ contract TestDecentralizedKV is DecentralizedKV {
         dataMap[kvIndices[0]] = data;
     }
 
+    function putBatch(bytes32[] memory _keys, bytes[] memory _data) public payable virtual {
+        require(_keys.length == _data.length, "TestDecentralizedKV: input length mismatch");
+
+        bytes32[] memory dataHashes = new bytes32[](_data.length);
+        uint256[] memory lengths = new uint256[](_data.length);
+        for (uint256 i = 0; i < _data.length; i++) {
+            dataHashes[i] = keccak256(_data[i]);
+            lengths[i] = _data[i].length;
+        }
+
+        uint256[] memory kvIndices = _putBatchInternal(_keys, dataHashes, lengths);
+        for (uint256 i = 0; i < kvIndices.length; i++) {
+            dataMap[kvIndices[i]] = _data[i];
+        }
+    }
+
     function get(bytes32 key, DecodeType decodeType, uint256 off, uint256 len)
         public
         view

--- a/contracts/test/TestEthStorageContract.sol
+++ b/contracts/test/TestEthStorageContract.sol
@@ -214,8 +214,4 @@ contract TestEthStorageContract is EthStorageContract {
         return
             _mineWithFixedHash0(initHash0, shardId, miner, nonce, encodedSamples, masks, inclusiveProofs, decodeProof);
     }
-
-    function updateCost() public view returns (uint256) {
-        return UPDATE_COST;
-    }
 }

--- a/contracts/test/TestEthStorageContract.sol
+++ b/contracts/test/TestEthStorageContract.sol
@@ -214,4 +214,8 @@ contract TestEthStorageContract is EthStorageContract {
         return
             _mineWithFixedHash0(initHash0, shardId, miner, nonce, encodedSamples, masks, inclusiveProofs, decodeProof);
     }
+
+    function updateCost() public view returns (uint256) {
+        return UPDATE_COST;
+    }
 }

--- a/test/decentralized-kv-test.js
+++ b/test/decentralized-kv-test.js
@@ -35,14 +35,16 @@ describe("DecentralizedKV Test", function () {
 
     await expect(kv.put(key1, "0x772233445566")).to.be.revertedWith("DecentralizedKV: not enough batch payment");
 
-    await kv.put(key1, "0x772233445566", { value: 150000000000000 });
+    const updateCost = kv.updateCost();
+
+    await kv.put(key1, "0x772233445566", { value: updateCost });
     expect(await kv.get(key1, 0, 0, 4)).to.equal("0x77223344");
     expect(await kv.get(key1, 0, 0, 6)).to.equal("0x772233445566");
 
-    await kv.put(key1, "0x8899", { value: 150000000000000 });
+    await kv.put(key1, "0x8899", { value: updateCost });
     expect(await kv.get(key1, 0, 0, 4)).to.equal("0x8899");
 
-    await kv.put(key1, "0x", { value: 150000000000000 });
+    await kv.put(key1, "0x", { value: updateCost });
     expect(await kv.get(key1, 0, 0, 4)).to.equal("0x");
   });
 

--- a/test/decentralized-kv-test.js
+++ b/test/decentralized-kv-test.js
@@ -33,14 +33,16 @@ describe("DecentralizedKV Test", function () {
     await kv.put(key1, "0x11223344");
     expect(await kv.get(key1, 0, 0, 4)).to.equal("0x11223344");
 
-    await kv.put(key1, "0x772233445566");
+    await expect(kv.put(key1, "0x772233445566")).to.be.revertedWith("DecentralizedKV: not enough batch payment");
+
+    await kv.put(key1, "0x772233445566", { value: 150000000000000 });
     expect(await kv.get(key1, 0, 0, 4)).to.equal("0x77223344");
     expect(await kv.get(key1, 0, 0, 6)).to.equal("0x772233445566");
 
-    await kv.put(key1, "0x8899");
+    await kv.put(key1, "0x8899", { value: 150000000000000 });
     expect(await kv.get(key1, 0, 0, 4)).to.equal("0x8899");
 
-    await kv.put(key1, "0x");
+    await kv.put(key1, "0x", { value: 150000000000000 });
     expect(await kv.get(key1, 0, 0, 4)).to.equal("0x");
   });
 


### PR DESCRIPTION
Add a dust cost for the update required by https://github.com/ethstorage/storage-contracts-v1/issues/36.

A constant `UPDATE_COST` is added meaning how much should be charged to update a KV entry or blob.  Using constant to be compatible with the currently deployed contract, and may change to immutable later.

The estimated value of 120,000 Gwei is derived from the maximum possible gas cost of a `putBlobs` batch transaction with a size of 4,872 for the same key, but containing only one blob. In this scenario, the gas used is 29,454,363, which means approximately the gas cost per kv update is 29454363 / 4872 = 6045. 

Assuming a gas price of 10 Gwei and a blob fee of 1 wei per gas unit,
(10000000000 * 29454363 + 1 * 131072) / 4872 =  60456 Gwei 

Round to 60000 and doubled to be on the safe side.

If the DoSer does not care about the gas cost, an extra charge doubles the cost to prevent the attack. On the other hand, a price less than one-tenth of adding a new entry (storageCost = 1,500,000 Gwei) justifies the updates with good reason.