### PR TITLE
Update limit for L2

### DIFF
--- a/contracts/DecentralizedKV.sol
+++ b/contracts/DecentralizedKV.sol
@@ -156,7 +156,9 @@ contract DecentralizedKV is OwnableUpgradeable {
         }
 
         _checkAppend(batchPaymentSize);
-        _checkUpdateLimit(_keys.length - batchPaymentSize);
+        if (_keys.length > batchPaymentSize) {
+            _checkUpdateLimit(_keys.length - batchPaymentSize);
+        }
 
         return res;
     }

--- a/contracts/DecentralizedKV.sol
+++ b/contracts/DecentralizedKV.sol
@@ -119,6 +119,9 @@ contract DecentralizedKV is OwnableUpgradeable {
         require(msg.value >= upfrontPayment() * _batchSize, "DecentralizedKV: not enough batch payment");
     }
 
+    /// @notice Check the update rate limit of blobs put (L2 only).
+    function _checkUpdateLimit(uint256 _blobs) internal virtual {}
+
     /// @notice Called by public putBlob and putBlobs methods.
     /// @param _keys       Keys of the data.
     /// @param _dataHashes Hashes of the data.
@@ -153,6 +156,7 @@ contract DecentralizedKV is OwnableUpgradeable {
         }
 
         _checkAppend(batchPaymentSize);
+        _checkUpdateLimit(_keys.length - batchPaymentSize);
 
         return res;
     }

--- a/contracts/DecentralizedKV.sol
+++ b/contracts/DecentralizedKV.sol
@@ -119,8 +119,8 @@ contract DecentralizedKV is OwnableUpgradeable {
         require(msg.value >= upfrontPayment() * _batchSize, "DecentralizedKV: not enough batch payment");
     }
 
-    /// @notice Check the update rate limit of blobs put (L2 only).
-    function _checkUpdateLimit(uint256 _blobs) internal virtual {}
+    /// @notice Check if the key-values being updated exceed the limit per block (L2 only).
+    function _checkUpdateLimit(uint256 _updateSize) internal virtual {}
 
     /// @notice Called by public putBlob and putBlobs methods.
     /// @param _keys       Keys of the data.

--- a/contracts/EthStorageContractL2.sol
+++ b/contracts/EthStorageContractL2.sol
@@ -68,15 +68,9 @@ contract EthStorageContractL2 is EthStorageContract2 {
     /// @notice Check the update rate limit of blobs put.
     function _checkUpdateLimit(uint256 _blobs) internal override {
         uint256 blockLastUpdate = updateState >> 32;
-        if (blockLastUpdate == block.number) {
-            uint256 blobsUpdated = updateState & type(uint32).max;
-            blobsUpdated += _blobs;
-            require(blobsUpdated <= UPDATE_LIMIT, "EthStorageContractL2: exceeds update rate limit");
-            updateState = block.number << 32 | blobsUpdated;
-        } else {
-            require(_blobs <= UPDATE_LIMIT, "EthStorageContractL2: exceeds update rate limit");
-            updateState = block.number << 32 | _blobs;
-        }
+        uint256 blobsUpdated = blockLastUpdate == block.number ? updateState & type(uint32).max : 0;
+        require(blobsUpdated + _blobs <= UPDATE_LIMIT, "EthStorageContractL2: exceeds update rate limit");
+        updateState = block.number << 32 | (blobsUpdated + _blobs);
     }
 
     /// @notice Getter for UPDATE_LIMIT

--- a/contracts/EthStorageContractL2.sol
+++ b/contracts/EthStorageContractL2.sol
@@ -69,11 +69,11 @@ contract EthStorageContractL2 is EthStorageContract2 {
         return RandaoLib.verifyHeaderAndGetRandao(bh, _headerRlpBytes);
     }
 
-    /// @notice Check the update rate limit of blobs put.
-    function _checkUpdateLimit(uint256 _blobs) internal override {
+    /// @notice Check if the key-values being updated exceed the limit per block.
+    function _checkUpdateLimit(uint256 _updateSize) internal override {
         uint256 blobsUpdated = updateState & MASK == block.number << 32 ? updateState & type(uint32).max : 0;
-        require(blobsUpdated + _blobs <= UPDATE_LIMIT, "EthStorageContractL2: exceeds update rate limit");
-        updateState = block.number << 32 | (blobsUpdated + _blobs);
+        require(blobsUpdated + _updateSize <= UPDATE_LIMIT, "EthStorageContractL2: exceeds update rate limit");
+        updateState = block.number << 32 | (blobsUpdated + _updateSize);
     }
 
     /// @notice Getter for UPDATE_LIMIT

--- a/contracts/EthStorageContractL2.sol
+++ b/contracts/EthStorageContractL2.sol
@@ -67,16 +67,15 @@ contract EthStorageContractL2 is EthStorageContract2 {
 
     /// @notice Check the update rate limit of blobs put.
     function _checkUpdateLimit(uint256 _blobs) internal override {
-        uint256 currentBlock = _blockNumber();
         uint256 blockLastUpdate = updateState & type(uint224).max;
-        if (blockLastUpdate == currentBlock) {
+        if (blockLastUpdate == block.number) {
             uint256 blobsUpdated = updateState >> 224;
             blobsUpdated += _blobs;
             require(blobsUpdated <= UPDATE_LIMIT, "EthStorageContractL2: exceeds update rate limit");
-            updateState = (blobsUpdated << 224) | currentBlock;
+            updateState = (blobsUpdated << 224) | block.number;
         } else {
             require(_blobs <= UPDATE_LIMIT, "EthStorageContractL2: exceeds update rate limit");
-            updateState = (_blobs << 224) | currentBlock;
+            updateState = (_blobs << 224) | block.number;
         }
     }
 

--- a/contracts/EthStorageContractL2.sol
+++ b/contracts/EthStorageContractL2.sol
@@ -29,8 +29,8 @@ contract EthStorageContractL2 is EthStorageContract2 {
     /// @notice The rate limit to update blobs per block
     uint256 internal immutable UPDATE_LIMIT;
 
-    /// @notice Bitmap to store blobsUpdated (left 32) and blockLastUpdate (right 224)
-    uint256 internal updateStateBitmap;
+    /// @notice A slot to store both `blobsUpdated` (left 32) and `blockLastUpdate` (right 224)
+    uint256 internal updateState;
 
     /// @notice Constructs the EthStorageContractL2 contract.
     constructor(
@@ -68,15 +68,15 @@ contract EthStorageContractL2 is EthStorageContract2 {
     /// @notice Check the update rate limit of blobs put.
     function _checkUpdateLimit(uint256 _blobs) internal override {
         uint256 currentBlock = _blockNumber();
-        uint256 blockLastUpdate = updateStateBitmap & type(uint224).max;
+        uint256 blockLastUpdate = updateState & type(uint224).max;
         if (blockLastUpdate == currentBlock) {
-            uint256 blobsUpdated = updateStateBitmap >> 224;
+            uint256 blobsUpdated = updateState >> 224;
             blobsUpdated += _blobs;
             require(blobsUpdated <= UPDATE_LIMIT, "EthStorageContractL2: exceeds update rate limit");
-            updateStateBitmap = (blobsUpdated << 224) | currentBlock;
+            updateState = (blobsUpdated << 224) | currentBlock;
         } else {
             require(_blobs <= UPDATE_LIMIT, "EthStorageContractL2: exceeds update rate limit");
-            updateStateBitmap = (_blobs << 224) | currentBlock;
+            updateState = (_blobs << 224) | currentBlock;
         }
     }
 

--- a/contracts/EthStorageContractL2.sol
+++ b/contracts/EthStorageContractL2.sol
@@ -27,16 +27,22 @@ contract EthStorageContractL2 is EthStorageContract2 {
     /// @notice The precompile contract address for L1Block.
     IL1Block internal constant L1_BLOCK = IL1Block(0x4200000000000000000000000000000000000015);
     /// @notice The rate limit to update blobs per block
-    uint256 internal constant UPDATE_LIMIT = 512;
+    uint256 internal immutable UPDATE_LIMIT;
     /// @notice The blobs updated within current block
     uint256 internal blobsUpdated;
     /// @notice The block last update happens
     uint256 internal blockLastUpdate;
 
     /// @notice Constructs the EthStorageContractL2 contract.
-    constructor(Config memory _config, uint256 _startTime, uint256 _storageCost, uint256 _dcfFactor)
-        EthStorageContract2(_config, _startTime, _storageCost, _dcfFactor)
-    {}
+    constructor(
+        Config memory _config,
+        uint256 _startTime,
+        uint256 _storageCost,
+        uint256 _dcfFactor,
+        uint256 _updateLimit
+    ) EthStorageContract2(_config, _startTime, _storageCost, _dcfFactor) {
+        UPDATE_LIMIT = _updateLimit;
+    }
 
     /// @notice Get the current block number
     function _blockNumber() internal view virtual override returns (uint256) {
@@ -69,5 +75,10 @@ contract EthStorageContractL2 is EthStorageContract2 {
             blobsUpdated = _blobs;
         }
         require(blobsUpdated <= UPDATE_LIMIT, "EthStorageContractL2: exceeds update rate limit");
+    }
+
+    /// @notice Getter for UPDATE_LIMIT
+    function getUpdateLimit() public view returns (uint256) {
+        return UPDATE_LIMIT;
     }
 }

--- a/contracts/EthStorageContractL2.sol
+++ b/contracts/EthStorageContractL2.sol
@@ -29,7 +29,7 @@ contract EthStorageContractL2 is EthStorageContract2 {
     /// @notice The rate limit to update blobs per block
     uint256 internal immutable UPDATE_LIMIT;
 
-    /// @notice Bitmap to store blobsUpdated and blockLastUpdate
+    /// @notice Bitmap to store blobsUpdated (left 32) and blockLastUpdate (right 224)
     uint256 internal updateStateBitmap;
 
     /// @notice Constructs the EthStorageContractL2 contract.
@@ -68,15 +68,15 @@ contract EthStorageContractL2 is EthStorageContract2 {
     /// @notice Check the update rate limit of blobs put.
     function _checkUpdateLimit(uint256 _blobs) internal override {
         uint256 currentBlock = _blockNumber();
-        uint256 blockLastUpdate = updateStateBitmap & type(uint128).max;
+        uint256 blockLastUpdate = updateStateBitmap & type(uint224).max;
         if (blockLastUpdate == currentBlock) {
-            uint256 blobsUpdated = updateStateBitmap >> 128;
+            uint256 blobsUpdated = updateStateBitmap >> 224;
             blobsUpdated += _blobs;
             require(blobsUpdated <= UPDATE_LIMIT, "EthStorageContractL2: exceeds update rate limit");
-            updateStateBitmap = (blobsUpdated << 128) | currentBlock;
+            updateStateBitmap = (blobsUpdated << 224) | currentBlock;
         } else {
             require(_blobs <= UPDATE_LIMIT, "EthStorageContractL2: exceeds update rate limit");
-            updateStateBitmap = (_blobs << 128) | currentBlock;
+            updateStateBitmap = (_blobs << 224) | currentBlock;
         }
     }
 

--- a/contracts/test/EthStorageContractL2Test.t.sol
+++ b/contracts/test/EthStorageContractL2Test.t.sol
@@ -1,0 +1,56 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.0;
+
+import "forge-std/Test.sol";
+import "./TestEthStorageContractL2.sol";
+import "@openzeppelin/contracts/proxy/transparent/TransparentUpgradeableProxy.sol";
+
+contract EthStorageContractL2Test is Test {
+    uint256 constant STORAGE_COST = 0;
+    uint256 constant SHARD_SIZE_BITS = 19;
+    uint256 constant MAX_KV_SIZE = 17;
+    uint256 constant PREPAID_AMOUNT = 0;
+
+    TestEthStorageContractL2 storageContract;
+    address owner = address(0x1);
+
+    function setUp() public {
+        TestEthStorageContractL2 imp = new TestEthStorageContractL2(
+            StorageContract.Config(MAX_KV_SIZE, SHARD_SIZE_BITS, 2, 0, 0, 0), 0, STORAGE_COST, 0
+        );
+        bytes memory data = abi.encodeWithSelector(
+            storageContract.initialize.selector, 0, PREPAID_AMOUNT, 0, address(0x1), address(0x1)
+        );
+        TransparentUpgradeableProxy proxy = new TransparentUpgradeableProxy(address(imp), owner, data);
+
+        storageContract = TestEthStorageContractL2(address(proxy));
+    }
+
+    function testCheckUpdateLimitWithinSameBlock() public {
+        uint256 size = 6;
+        bytes32[] memory hashes = new bytes32[](size);
+        bytes32[] memory keys = new bytes32[](size);
+        uint256[] memory blobIdxs = new uint256[](size);
+        uint256[] memory lengths = new uint256[](size);
+        for (uint256 i = 0; i < size; i++) {
+            keys[i] = bytes32(uint256(i));
+            hashes[i] = bytes32(uint256((i + 1) << 64));
+            blobIdxs[i] = i;
+            lengths[i] = 10 + i * 10;
+        }
+        vm.blobhashes(hashes);
+        vm.roll(10000);
+
+        // No updates
+        storageContract.putBlobs(keys, blobIdxs, lengths);
+        assertEq(storageContract.getBlobsUpdated(), 0);
+        assertEq(storageContract.getBlockLastUpdate(), 10000);
+
+        // Append 2 new key-values, leaving 4 as updating
+        keys[0] = bytes32(uint256(10));
+        keys[1] = bytes32(uint256(11));
+        storageContract.putBlobs(keys, blobIdxs, lengths);
+        assertEq(storageContract.getBlobsUpdated(), 4);
+        assertEq(storageContract.getBlockLastUpdate(), 10000);
+    }
+}

--- a/contracts/test/EthStorageContractL2Test.t.sol
+++ b/contracts/test/EthStorageContractL2Test.t.sol
@@ -45,7 +45,7 @@ contract EthStorageContractL2Test is Test {
         // No updates
         storageContract.putBlobs(keys, blobIdxs, lengths);
         assertEq(storageContract.getBlobsUpdated(), 0);
-        assertEq(storageContract.getBlockLastUpdate(), 10000);
+        assertEq(storageContract.getBlockLastUpdate(), 0);
 
         // Append 1 new key-values, leaving 5 as updating
         keys[0] = bytes32(uint256(10));

--- a/contracts/test/EthStorageContractTest.t.sol
+++ b/contracts/test/EthStorageContractTest.t.sol
@@ -63,7 +63,7 @@ contract EthStorageContractTest is Test {
         keys[1] = bytes32(uint256(1));
         uint256[] memory blobIdxs = new uint256[](2);
         blobIdxs[0] = 0;
-        blobIdxs[1] = 0;
+        blobIdxs[1] = 1;
         uint256[] memory lengths = new uint256[](2);
         lengths[0] = 10;
         lengths[1] = 20;

--- a/contracts/test/TestEthStorageContractL2.sol
+++ b/contracts/test/TestEthStorageContractL2.sol
@@ -14,12 +14,12 @@ contract TestEthStorageContractL2 is EthStorageContractL2 {
 
     /// @notice Get the number of blobs updated within the current block.
     function getBlobsUpdated() public view returns (uint256) {
-        return updateStateBitmap >> 128;
+        return updateStateBitmap >> 224;
     }
 
     /// @notice Get the block number of the last update.
     function getBlockLastUpdate() public view returns (uint256) {
-        return updateStateBitmap & type(uint128).max;
+        return updateStateBitmap & type(uint224).max;
     }
 
     function _blockNumber() internal view virtual override returns (uint256) {

--- a/contracts/test/TestEthStorageContractL2.sol
+++ b/contracts/test/TestEthStorageContractL2.sol
@@ -14,12 +14,12 @@ contract TestEthStorageContractL2 is EthStorageContractL2 {
 
     /// @notice Get the number of blobs updated within the current block.
     function getBlobsUpdated() public view returns (uint256) {
-        return updateState >> 224;
+        return updateState & type(uint32).max;
     }
 
     /// @notice Get the block number of the last update.
     function getBlockLastUpdate() public view returns (uint256) {
-        return updateState & type(uint224).max;
+        return updateState >> 32;
     }
 
     function _blockNumber() internal view virtual override returns (uint256) {

--- a/contracts/test/TestEthStorageContractL2.sol
+++ b/contracts/test/TestEthStorageContractL2.sol
@@ -1,0 +1,27 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.0;
+
+import "../EthStorageContractL2.sol";
+
+contract TestEthStorageContractL2 is EthStorageContractL2 {
+    constructor(Config memory _config, uint256 _startTime, uint256 _storageCost, uint256 _dcfFactor)
+        EthStorageContractL2(_config, _startTime, _storageCost, _dcfFactor)
+    {}
+
+    function getBlobsUpdated() public view returns (uint256) {
+        return blobsUpdated;
+    }
+
+    function getBlockLastUpdate() public view returns (uint256) {
+        return blockLastUpdate;
+    }
+
+    function _blockNumber() internal view virtual override returns (uint256) {
+        return block.number;
+    }
+
+    /// @notice Get the current block timestamp
+    function _blockTs() internal view virtual override returns (uint256) {
+        return block.timestamp;
+    }
+}

--- a/contracts/test/TestEthStorageContractL2.sol
+++ b/contracts/test/TestEthStorageContractL2.sol
@@ -12,12 +12,14 @@ contract TestEthStorageContractL2 is EthStorageContractL2 {
         uint256 _updateLimit
     ) EthStorageContractL2(_config, _startTime, _storageCost, _dcfFactor, _updateLimit) {}
 
+    /// @notice Get the number of blobs updated within the current block.
     function getBlobsUpdated() public view returns (uint256) {
-        return blobsUpdated;
+        return updateStateBitmap >> 128;
     }
 
+    /// @notice Get the block number of the last update.
     function getBlockLastUpdate() public view returns (uint256) {
-        return blockLastUpdate;
+        return updateStateBitmap & type(uint128).max;
     }
 
     function _blockNumber() internal view virtual override returns (uint256) {

--- a/contracts/test/TestEthStorageContractL2.sol
+++ b/contracts/test/TestEthStorageContractL2.sol
@@ -14,12 +14,12 @@ contract TestEthStorageContractL2 is EthStorageContractL2 {
 
     /// @notice Get the number of blobs updated within the current block.
     function getBlobsUpdated() public view returns (uint256) {
-        return updateStateBitmap >> 224;
+        return updateState >> 224;
     }
 
     /// @notice Get the block number of the last update.
     function getBlockLastUpdate() public view returns (uint256) {
-        return updateStateBitmap & type(uint224).max;
+        return updateState & type(uint224).max;
     }
 
     function _blockNumber() internal view virtual override returns (uint256) {

--- a/contracts/test/TestEthStorageContractL2.sol
+++ b/contracts/test/TestEthStorageContractL2.sol
@@ -4,9 +4,13 @@ pragma solidity ^0.8.0;
 import "../EthStorageContractL2.sol";
 
 contract TestEthStorageContractL2 is EthStorageContractL2 {
-    constructor(Config memory _config, uint256 _startTime, uint256 _storageCost, uint256 _dcfFactor)
-        EthStorageContractL2(_config, _startTime, _storageCost, _dcfFactor)
-    {}
+    constructor(
+        Config memory _config,
+        uint256 _startTime,
+        uint256 _storageCost,
+        uint256 _dcfFactor,
+        uint256 _updateLimit
+    ) EthStorageContractL2(_config, _startTime, _storageCost, _dcfFactor, _updateLimit) {}
 
     function getBlobsUpdated() public view returns (uint256) {
         return blobsUpdated;

--- a/contracts/test/TestStorageContract.sol
+++ b/contracts/test/TestStorageContract.sol
@@ -1,4 +1,4 @@
-// SPDX License Identifier: MIT
+// SPDX-License-Identifier: MIT
 pragma solidity ^0.8.0;
 
 import "../StorageContract.sol";

--- a/scripts/deployL2-it.js
+++ b/scripts/deployL2-it.js
@@ -20,6 +20,7 @@ const config = [
 ];
 const storageCost = 1500000000000000; // storageCost - 1,500,000Gwei forever per blob - https://ethresear.ch/t/ethstorage-scaling-ethereum-storage-via-l2-and-da/14223/6#incentivization-for-storing-m-physical-replicas-1
 const dcfFactor = 340282366367469178095360967382638002176n; // dcfFactor, it mean 0.95 for yearly discount
+const updateLimit = 90; // 45 blobs/s according to sync/encoding test, times block interval of L2
 
 async function verifyContract(contract, args) {
   // if (!process.env.ETHERSCAN_API_KEY) {
@@ -45,6 +46,7 @@ async function deployContract() {
     startTime, // startTime
     storageCost,
     dcfFactor,
+    updateLimit,
     { gasPrice: gasPrice }
   );
   await implContract.deployed();
@@ -85,7 +87,7 @@ async function deployContract() {
   await verifyContract(impl, [config, startTime, storageCost, dcfFactor]);
 
   // wait for contract finalized
-  var intervalId = setInterval(async function (){
+  var intervalId = setInterval(async function () {
     try {
       const block = await hre.ethers.provider.getBlock("finalized");
       console.log(
@@ -93,13 +95,13 @@ async function deployContract() {
         block.number,
         "at",
         new Date().toLocaleTimeString([], { hour: "2-digit", minute: "2-digit", second: "2-digit" })
-        );
+      );
       if (receipt.blockNumber < block.number) {
         fs.writeFileSync(".caddr", ethStorageProxy.address);
         clearInterval(intervalId);
       }
     } catch (e) {
-      console.error(`EthStorage: get finalized block failed!`, e.message);g
+      console.error(`EthStorage: get finalized block failed!`, e.message);
     }
   }, 60000);
 }

--- a/scripts/deployL2.js
+++ b/scripts/deployL2.js
@@ -77,7 +77,7 @@ async function deployContract() {
 
   // fund 50 qkc into the storage contract to give reward for empty mining
   const ethStorage = StorageContract.attach(ethStorageProxy.address);
-  const tx = await ethStorage.sendValue({ value: hre.ethers.utils.parseEther("1") });
+  const tx = await ethStorage.sendValue({ value: hre.ethers.utils.parseEther("50") });
   await tx.wait();
   console.log("balance of " + ethStorage.address, await hre.ethers.provider.getBalance(ethStorage.address));
 

--- a/scripts/deployL2.js
+++ b/scripts/deployL2.js
@@ -19,7 +19,7 @@ const config = [
 ];
 const storageCost = 1500000000000000; // storageCost - 1,500,000Gwei forever per blob - https://ethresear.ch/t/ethstorage-scaling-ethereum-storage-via-l2-and-da/14223/6#incentivization-for-storing-m-physical-replicas-1
 const dcfFactor = 340282366367469178095360967382638002176n; // dcfFactor, it mean 0.95 for yearly discount
-const updateLimit = 512;
+const updateLimit = 90; // 45 blobs/s according to sync/encoding test, times block interval of L2
 
 async function verifyContract(contract, args) {
   // if (!process.env.ETHERSCAN_API_KEY) {

--- a/scripts/deployL2.js
+++ b/scripts/deployL2.js
@@ -19,6 +19,7 @@ const config = [
 ];
 const storageCost = 1500000000000000; // storageCost - 1,500,000Gwei forever per blob - https://ethresear.ch/t/ethstorage-scaling-ethereum-storage-via-l2-and-da/14223/6#incentivization-for-storing-m-physical-replicas-1
 const dcfFactor = 340282366367469178095360967382638002176n; // dcfFactor, it mean 0.95 for yearly discount
+const updateLimit = 512;
 
 async function verifyContract(contract, args) {
   // if (!process.env.ETHERSCAN_API_KEY) {
@@ -44,6 +45,7 @@ async function deployContract() {
     startTime, // startTime
     storageCost,
     dcfFactor,
+    updateLimit,
     { gasPrice: gasPrice }
   );
   await implContract.deployed();
@@ -75,7 +77,7 @@ async function deployContract() {
 
   // fund 50 qkc into the storage contract to give reward for empty mining
   const ethStorage = StorageContract.attach(ethStorageProxy.address);
-  const tx = await ethStorage.sendValue({ value: hre.ethers.utils.parseEther("50") });
+  const tx = await ethStorage.sendValue({ value: hre.ethers.utils.parseEther("1") });
   await tx.wait();
   console.log("balance of " + ethStorage.address, await hre.ethers.provider.getBalance(ethStorage.address));
 


### PR DESCRIPTION
Addressing https://github.com/ethstorage/storage-contracts-v1/issues/36 using a rate limit for updating on L2 contract.

The value of the limit is evaluated in the following tests:

Deploy a test storage contract on an L2 network with 8192 entries per shard. Set up an RPC es-node as a bootstrap node and download a full shard containing 8192 uploaded blobs. 
Afterward, start another es-node, connect it to the bootstrap node, and observe the synchronization process fully utilizing the CPU cores. 
Finally, note the time taken and the number of blobs synchronized according to logs. 

The test results of 3 times syncs are 46, 40, and 49 separately, 45 on average.
As the block interval is 2 on L2 we set `UPDATE_LIMIT` as 45*2 = 90.

Tests with an L2 contract using a modified version of sdk to update over `UPDATE_LIMIT` with the same key, failed with `exceeds update rate limit`.
