### PR TITLE
update difficulty for integration test

### DIFF
--- a/scripts/deployL2-it.js
+++ b/scripts/deployL2-it.js
@@ -52,7 +52,7 @@ async function deployContract() {
   console.log("storage impl address is ", impl);
 
   const data = implContract.interface.encodeFunctionData("initialize", [
-    1572864, // minimumDiff 0.1 * 180 (3 minutes) * 1024 * 1024 / 12 = 1572864 for 0.1 replicas that can have 1M IOs in one epoch
+    5242880, // minimumDiff 0.1 * 600 (10 minutes) * 1024 * 1024 / 12 = 5242880 for 0.1 replicas that can have 1M IOs in one epoch
     6144000000000000000n, // prepaidAmount - 50% * 2^30 / 131072 * 1500000Gwei, it also means 3145 ETH for half of the shard
     1048576, // nonceLimit 1024 * 1024 = 1M samples and finish sampling in 1.3s with IO rate 6144 MB/s: 4k * 2(random checks) / 6144 = 1.3s
     treasuryAddress, // treasury

--- a/scripts/deployL2-it.js
+++ b/scripts/deployL2-it.js
@@ -54,7 +54,7 @@ async function deployContract() {
   console.log("storage impl address is ", impl);
 
   const data = implContract.interface.encodeFunctionData("initialize", [
-    5242880, // minimumDiff 0.1 * 600 (10 minutes) * 1024 * 1024 / 12 = 5242880 for 0.1 replicas that can have 1M IOs in one epoch
+    10485760, // minimumDiff 0.1 * 1200 (20 minutes) * 1024 * 1024 / 12 = 10485760 for 0.1 replicas that can have 1M IOs in one epoch
     6144000000000000000n, // prepaidAmount - 50% * 2^30 / 131072 * 1500000Gwei, it also means 3145 ETH for half of the shard
     1048576, // nonceLimit 1024 * 1024 = 1M samples and finish sampling in 1.3s with IO rate 6144 MB/s: 4k * 2(random checks) / 6144 = 1.3s
     treasuryAddress, // treasury


### PR DESCRIPTION
Currently, the integration test fails with [issue 304](https://github.com/ethstorage/es-node/issues/304) because the difficulty is too small and the submission is too frequent. So increasing the minimumDiff to resolve this issue.
