### PR TITLE
Fix warnings

### DIFF
--- a/contracts/test/EthStorageContractTest.t.sol
+++ b/contracts/test/EthStorageContractTest.t.sol
@@ -3,8 +3,6 @@ pragma solidity ^0.8.19;
 
 import "./TestEthStorageContract.sol";
 import "forge-std/Test.sol";
-import "forge-std/Vm.sol";
-import "forge-std/console.sol";
 import "@openzeppelin/contracts/proxy/transparent/TransparentUpgradeableProxy.sol";
 
 contract EthStorageContractTest is Test {

--- a/contracts/test/StorageContractTest.t.sol
+++ b/contracts/test/StorageContractTest.t.sol
@@ -1,11 +1,9 @@
 // SPDX-License-Identifier: UNLICENSED
 pragma solidity ^0.8.19;
 
-import "@openzeppelin/contracts/utils/ReentrancyGuard.sol";
 import "./TestStorageContract.sol";
 import "../StorageContract.sol";
 import "forge-std/Test.sol";
-import "forge-std/Vm.sol";
 
 contract StorageContractTest is Test {
     uint256 constant STORAGE_COST = 10000000;
@@ -172,7 +170,7 @@ contract Attacker is Test {
         storageContract = _storageContract;
     }
 
-    fallback() external payable {
+    receive() external payable {
         uint256 _shardId = 0;
         uint256 _nonce = 0;
         bytes32[] memory _encodedSamples = new bytes32[](0);

--- a/contracts/test/TestDecentralizedKV.sol
+++ b/contracts/test/TestDecentralizedKV.sol
@@ -39,7 +39,7 @@ contract TestDecentralizedKV is DecentralizedKV {
         dataMap[kvIndices[0]] = data;
     }
 
-    function get(bytes32 key, DecodeType decodeType, uint256 off, uint256 len)
+    function get(bytes32 key, DecodeType, /* decodeType */ uint256 off, uint256 len)
         public
         view
         override

--- a/contracts/test/TestEthStorageContract.sol
+++ b/contracts/test/TestEthStorageContract.sol
@@ -36,7 +36,7 @@ contract TestEthStorageContract is EthStorageContract {
         _putBatchInternal(keys, dataHashes, lengths);
     }
 
-    function putBlob(bytes32 _key, uint256 _blobIdx, uint256 _length) public payable override {
+    function putBlob(bytes32 _key, uint256, /* _blobIdx */ uint256 _length) public payable override {
         bytes32 dataHash = bytes32(uint256(1 << 8 * 8));
         require(dataHash != 0, "EthStorageContract: failed to get blob hash");
 
@@ -194,7 +194,7 @@ contract TestEthStorageContract is EthStorageContract {
         require(nonce < nonceLimit, "nonce too big");
 
         // Check if the data matches the hash in metadata and obtain the solution hash.
-        bytes32 hash0 = verifySamples(shardId, initHash0, miner, encodedSamples, masks, inclusiveProofs, decodeProof);
+        verifySamples(shardId, initHash0, miner, encodedSamples, masks, inclusiveProofs, decodeProof);
 
         uint256 diff = _calculateDiffAndInitHashSingleShard(shardId, mineTs);
 

--- a/contracts/test/TestMerkleLib.sol
+++ b/contracts/test/TestMerkleLib.sol
@@ -12,29 +12,27 @@ contract TestMerkleLib {
         return MerkleLib.merkleRootWithMinTree(data, chunkSize);
     }
 
-    function merkleRootNoView(bytes memory data, uint256 chunkSize, uint256 nChunkBits) public returns (bytes32) {
+    function merkleRootNoView(bytes memory data, uint256 chunkSize, uint256 nChunkBits) public pure returns (bytes32) {
         return MerkleLib.merkleRoot(data, chunkSize, nChunkBits);
     }
 
-    function keccak256NoView(bytes memory data) public returns (bytes32) {
+    function keccak256NoView(bytes memory data) public pure returns (bytes32) {
         return keccak256(data);
     }
 
-    function verify(
-        bytes memory chunkData,
-        uint256 chunkIdx,
-        bytes32 root,
-        bytes32[] memory proofs
-    ) public pure returns (bool) {
+    function verify(bytes memory chunkData, uint256 chunkIdx, bytes32 root, bytes32[] memory proofs)
+        public
+        pure
+        returns (bool)
+    {
         return MerkleLib.verify(keccak256(chunkData), chunkIdx, root, proofs);
     }
 
-    function getProof(
-        bytes memory data,
-        uint256 chunkSize,
-        uint256 nChunkBits,
-        uint256 chunkIdx
-    ) public pure returns (bytes32[] memory) {
+    function getProof(bytes memory data, uint256 chunkSize, uint256 nChunkBits, uint256 chunkIdx)
+        public
+        pure
+        returns (bytes32[] memory)
+    {
         return MerkleLib.getProof(data, chunkSize, nChunkBits, chunkIdx);
     }
 

--- a/contracts/test/TestStorageContract.sol
+++ b/contracts/test/TestStorageContract.sol
@@ -19,13 +19,13 @@ contract TestStorageContract is StorageContract {
     }
 
     function verifySamples(
-        uint256 _startShardId,
-        bytes32 _hash0,
-        address _miner,
-        bytes32[] memory _encodedSamples,
-        uint256[] memory _masks,
-        bytes[] calldata _inclusiveProofs,
-        bytes[] calldata _decodeProof
+        uint256, /* _startShardId */
+        bytes32, /* _hash0 */
+        address, /* _miner */
+        bytes32[] memory, /* _encodedSamples */
+        uint256[] memory, /* _masks */
+        bytes[] calldata, /* _inclusiveProofs */
+        bytes[] calldata /* _decodeProof */
     ) public pure override returns (bytes32) {
         return bytes32(0);
     }
@@ -50,12 +50,12 @@ contract TestStorageContract is StorageContract {
         uint256 _blockNum,
         uint256 _shardId,
         address _miner,
-        uint256 _nonce,
-        bytes32[] memory _encodedSamples,
-        uint256[] memory _masks,
-        bytes calldata _randaoProof,
-        bytes[] calldata _inclusiveProofs,
-        bytes[] calldata _decodeProof
+        uint256, /* _nonce */
+        bytes32[] memory, /* _encodedSamples */
+        uint256[] memory, /* _masks */
+        bytes calldata, /* _randaoProof */
+        bytes[] calldata, /* _inclusiveProofs */
+        bytes[] calldata /* å */
     ) internal override {
         uint256 mineTs = _getMinedTs(_blockNum);
         _rewardMiner(_shardId, _miner, mineTs, 1);

--- a/contracts/test/TestStorageContract.sol
+++ b/contracts/test/TestStorageContract.sol
@@ -55,7 +55,7 @@ contract TestStorageContract is StorageContract {
         uint256[] memory, /* _masks */
         bytes calldata, /* _randaoProof */
         bytes[] calldata, /* _inclusiveProofs */
-        bytes[] calldata /* å */
+        bytes[] calldata /* _decodeProof */
     ) internal override {
         uint256 mineTs = _getMinedTs(_blockNum);
         _rewardMiner(_shardId, _miner, mineTs, 1);


### PR DESCRIPTION
Fix warnings like
- `Warning: Unused function parameter. Remove or comment out the variable name to silence this warning.`
by commenting out the variable names. Leave `DecentralizedKV.sol: removeTo(bytes32 _key, address _to)` untouched because the documentation of params requires the names.

- `Warning: This contract has a payable fallback function, but no receive ether function. Consider adding a receive ether function.`
by using `receive()`

- Some `Warning: Contract code size is 26418 bytes and exceeds 24576 bytes (a limit introduced in Spurious Dragon). This contract may not be deployable on Mainnet. Consider enabling the optimizer (with a low "runs" value!), turning off revert strings, or using libraries.` 
by removing unnecessary imports.