### PR TITLE
Lock compiler version to 0.8.28

### DIFF
--- a/contracts/DecentralizedKV.sol
+++ b/contracts/DecentralizedKV.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.8.28;
+pragma solidity 0.8.28;
 
 import "@openzeppelin/contracts-upgradeable/access/Ownable2StepUpgradeable.sol";
 import "./libraries/MerkleLib.sol";

--- a/contracts/EthStorageContract.sol
+++ b/contracts/EthStorageContract.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.8.28;
+pragma solidity 0.8.28;
 
 import "./StorageContract.sol";
 import "./zk-verify/Decoder.sol";

--- a/contracts/EthStorageContract2.sol
+++ b/contracts/EthStorageContract2.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.8.28;
+pragma solidity 0.8.28;
 
 import "./EthStorageContract.sol";
 import "./zk-verify/Decoder2.sol";

--- a/contracts/EthStorageContractL2.sol
+++ b/contracts/EthStorageContractL2.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.8.28;
+pragma solidity 0.8.28;
 
 import "./EthStorageContract2.sol";
 

--- a/contracts/EthStorageUpgradeableProxy.sol
+++ b/contracts/EthStorageUpgradeableProxy.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.8.20;
+pragma solidity 0.8.28;
 
 import "@openzeppelin/contracts/proxy/transparent/TransparentUpgradeableProxy.sol";
 

--- a/contracts/Interfaces/IProxyAdmin.sol
+++ b/contracts/Interfaces/IProxyAdmin.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.8.20;
+pragma solidity 0.8.28;
 
 import {ITransparentUpgradeableProxy} from "@openzeppelin/contracts/proxy/transparent/TransparentUpgradeableProxy.sol";
 

--- a/contracts/Interfaces/ISemver.sol
+++ b/contracts/Interfaces/ISemver.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.8.0;
+pragma solidity 0.8.28;
 
 /// @title ISemver
 /// @notice ISemver is a simple contract for ensuring that contracts are

--- a/contracts/StorageContract.sol
+++ b/contracts/StorageContract.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.8.28;
+pragma solidity 0.8.28;
 
 import "./DecentralizedKV.sol";
 import "./libraries/MiningLib.sol";

--- a/contracts/libraries/BinaryRelated.sol
+++ b/contracts/libraries/BinaryRelated.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.8.0;
+pragma solidity 0.8.28;
 
 library BinaryRelated {
     function pow(uint256 fp, uint256 n) internal pure returns (uint256) {

--- a/contracts/libraries/MerkleLib.sol
+++ b/contracts/libraries/MerkleLib.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.8.0;
+pragma solidity 0.8.28;
 
 import "./BinaryRelated.sol";
 

--- a/contracts/libraries/MiningLib.sol
+++ b/contracts/libraries/MiningLib.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.8.0;
+pragma solidity 0.8.28;
 
 /// @title MiningLib
 /// @notice Handles mining difficulty calculation and mining info update

--- a/contracts/libraries/RLPReader.sol
+++ b/contracts/libraries/RLPReader.sol
@@ -4,7 +4,7 @@
  * Please reach out with any questions or concerns
  * https://github.com/hamdiallam/Solidity-RLP/blob/0212f8e754471da67fc5387df7855f47f944f925/contracts/RLPReader.sol
  */
-pragma solidity >=0.5.10 <0.9.0;
+pragma solidity 0.8.28;
 
 library RLPReader {
     uint8 constant STRING_SHORT_START = 0x80;

--- a/contracts/libraries/RandaoLib.sol
+++ b/contracts/libraries/RandaoLib.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.8.0;
+pragma solidity 0.8.28;
 
 import "./RLPReader.sol";
 

--- a/contracts/test/DecentralizedKVTest.t.sol
+++ b/contracts/test/DecentralizedKVTest.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: UNLICENSED
-pragma solidity ^0.8.28;
+pragma solidity 0.8.28;
 
 import "./TestDecentralizedKV.sol";
 import "forge-std/Test.sol";

--- a/contracts/test/EthStorageContractL2Test.t.sol
+++ b/contracts/test/EthStorageContractL2Test.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.8.28;
+pragma solidity 0.8.28;
 
 import "forge-std/Test.sol";
 import "./TestEthStorageContractL2.sol";

--- a/contracts/test/EthStorageContractTest.t.sol
+++ b/contracts/test/EthStorageContractTest.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: UNLICENSED
-pragma solidity ^0.8.28;
+pragma solidity 0.8.28;
 
 import "./TestEthStorageContract.sol";
 import "forge-std/Test.sol";

--- a/contracts/test/StorageContractTest.t.sol
+++ b/contracts/test/StorageContractTest.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: UNLICENSED
-pragma solidity ^0.8.28;
+pragma solidity 0.8.28;
 
 import "./TestStorageContract.sol";
 import "../StorageContract.sol";

--- a/contracts/test/TestDecentralizedKV.sol
+++ b/contracts/test/TestDecentralizedKV.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.8.0;
+pragma solidity 0.8.28;
 
 import "../DecentralizedKV.sol";
 

--- a/contracts/test/TestEthStorageContract.sol
+++ b/contracts/test/TestEthStorageContract.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.8.28;
+pragma solidity 0.8.28;
 
 import "../EthStorageContract.sol";
 import "../libraries/MerkleLib.sol";

--- a/contracts/test/TestEthStorageContractKZG.sol
+++ b/contracts/test/TestEthStorageContractKZG.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.8.28;
+pragma solidity 0.8.28;
 
 import "../EthStorageContract2.sol";
 

--- a/contracts/test/TestEthStorageContractL2.sol
+++ b/contracts/test/TestEthStorageContractL2.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.8.28;
+pragma solidity 0.8.28;
 
 import "../EthStorageContractL2.sol";
 

--- a/contracts/test/TestMerkleLib.sol
+++ b/contracts/test/TestMerkleLib.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.8.0;
+pragma solidity 0.8.28;
 
 import "../libraries/MerkleLib.sol";
 

--- a/contracts/test/TestRandao.sol
+++ b/contracts/test/TestRandao.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.8.0;
+pragma solidity 0.8.28;
 
 import "../libraries/RandaoLib.sol";
 

--- a/contracts/test/TestStorageContract.sol
+++ b/contracts/test/TestStorageContract.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.8.28;
+pragma solidity 0.8.28;
 
 import "../StorageContract.sol";
 

--- a/contracts/zk-verify/Decoder.sol
+++ b/contracts/zk-verify/Decoder.sol
@@ -11,7 +11,7 @@
 //
 //
 // SPDX-License-Identifier: GPL-3.0
-pragma solidity ^0.8.0;
+pragma solidity 0.8.28;
 
 library Pairing {
     struct G1Point {

--- a/contracts/zk-verify/Decoder2.sol
+++ b/contracts/zk-verify/Decoder2.sol
@@ -18,7 +18,7 @@
     along with snarkJS. If not, see <https://www.gnu.org/licenses/>.
 */
 
-pragma solidity >=0.7.0 <0.9.0;
+pragma solidity 0.8.28;
 
 contract Decoder2 {
     // Scalar field size


### PR DESCRIPTION
Use a locked pragma statement to ensure a deterministic bytecode. 
**Reason**: Floating pragma statements are discouraged, as they can result in different bytecodes when compiled with varying compiler versions.