### PR TITLE
Refactor EthStorageContract for smaller bytecode

### DIFF
--- a/contracts/DecentralizedKV.sol
+++ b/contracts/DecentralizedKV.sol
@@ -2,7 +2,6 @@
 pragma solidity 0.8.28;
 
 import "@openzeppelin/contracts-upgradeable/access/Ownable2StepUpgradeable.sol";
-import "./libraries/MerkleLib.sol";
 import "./libraries/BinaryRelated.sol";
 
 /// @custom:upgradeable

--- a/contracts/EthStorageContract.sol
+++ b/contracts/EthStorageContract.sol
@@ -2,14 +2,13 @@
 pragma solidity 0.8.28;
 
 import "./StorageContract.sol";
-import "./zk-verify/Decoder.sol";
 import "./libraries//BinaryRelated.sol";
 import "./Interfaces/ISemver.sol";
 
 /// @custom:proxied
 /// @title EthStorageContract
 /// @notice EthStorage Contract that using EIP-4844 BLOB
-contract EthStorageContract is StorageContract, Decoder, ISemver {
+abstract contract EthStorageContract is StorageContract, ISemver {
     /// @notice The modulus for the BLS curve
     uint256 internal constant MODULUS_BLS = 0x73eda753299d7d483339d80809a1d80553bda402fffe5bfeffffffff00000001;
 
@@ -108,27 +107,6 @@ contract EthStorageContract is StorageContract, Decoder, ISemver {
         }
     }
 
-    /// @notice Verify the mask is correct
-    /// @param _proof The ZK proof
-    /// @param _encodingKey The encoding key
-    /// @param _sampleIdxInKv The sample index in the KV
-    /// @param _mask The mask of the sample
-    /// @return The result of the verification
-    function decodeSample(Proof memory _proof, uint256 _encodingKey, uint256 _sampleIdxInKv, uint256 _mask)
-        public
-        view
-        returns (bool)
-    {
-        uint256 xBn254 = _modExp(RU_BN254, _sampleIdxInKv, MODULUS_BN254);
-
-        uint256[] memory input = new uint256[](3);
-        // TODO: simple hash to curve mapping
-        input[0] = _encodingKey % MODULUS_BN254;
-        input[1] = xBn254;
-        input[2] = _mask;
-        return (verifyDecoding(input, _proof) == 0);
-    }
-
     /// @notice Check the decoded data is included in the BLOB corresponding to on-chain datahashes
     /// @param _dataHash The data hash
     /// @param _sampleIdxInKv The sample index in the KV
@@ -154,35 +132,6 @@ contract EthStorageContract is StorageContract, Decoder, ISemver {
         return evalY == _decodedData;
     }
 
-    /// @notice Decode the sample and check the decoded sample is included in the BLOB corresponding to on-chain datahashes
-    /// @param _kvIdx The index of the KV pair
-    /// @param _sampleIdxInKv The sample index in the KV
-    /// @param _miner The miner address
-    /// @param _encodedData The encoded sample data
-    /// @param _mask The mask of the sample
-    /// @param _inclusiveProof The inclusive proof
-    /// @param _decodeProof The decode proof
-    /// @return The result of the check
-    function decodeAndCheckInclusive(
-        uint256 _kvIdx,
-        uint256 _sampleIdxInKv,
-        address _miner,
-        bytes32 _encodedData,
-        uint256 _mask,
-        bytes calldata _inclusiveProof,
-        bytes calldata _decodeProof
-    ) public view virtual returns (bool) {
-        PhyAddr memory kvInfo = kvMap[idxMap[_kvIdx]];
-        Proof memory proof = abi.decode(_decodeProof, (Proof));
-        // BLOB decoding check
-        if (!decodeSample(proof, uint256(keccak256(abi.encode(kvInfo.hash, _miner, _kvIdx))), _sampleIdxInKv, _mask)) {
-            return false;
-        }
-
-        // Inclusive proof of decodedData = mask ^ encodedData
-        return checkInclusive(kvInfo.hash, _sampleIdxInKv, _mask ^ uint256(_encodedData), _inclusiveProof);
-    }
-
     /// @notice Get the sample index
     /// @param _rows The sample count per shard
     /// @param _startShardId The start shard ID
@@ -199,38 +148,6 @@ contract EthStorageContract is StorageContract, Decoder, ISemver {
         uint256 kvIdx = sampleIdx >> SAMPLE_LEN_BITS;
         uint256 sampleIdxInKv = sampleIdx % (1 << SAMPLE_LEN_BITS);
         return (kvIdx, sampleIdxInKv);
-    }
-
-    /// @inheritdoc StorageContract
-    function verifySamples(
-        uint256 _startShardId,
-        bytes32 _hash0,
-        address _miner,
-        bytes32[] memory _encodedSamples,
-        uint256[] memory _masks,
-        bytes[] calldata _inclusiveProofs,
-        bytes[] calldata _decodeProof
-    ) public view virtual override returns (bytes32) {
-        require(_encodedSamples.length == RANDOM_CHECKS, "EthStorageContract: data length mismatch");
-        require(_masks.length == RANDOM_CHECKS, "EthStorageContract: masks length mismatch");
-        require(_inclusiveProofs.length == RANDOM_CHECKS, "EthStorageContract: proof length mismatch");
-        require(_decodeProof.length == RANDOM_CHECKS, "EthStorageContract: decodeProof length mismatch");
-
-        // calculate the number of samples range of the sample check
-        uint256 rows = 1 << (SHARD_ENTRY_BITS + SAMPLE_LEN_BITS);
-
-        for (uint256 i = 0; i < RANDOM_CHECKS; i++) {
-            (uint256 kvIdx, uint256 sampleIdxInKv) = getSampleIdx(rows, _startShardId, _hash0);
-
-            require(
-                decodeAndCheckInclusive(
-                    kvIdx, sampleIdxInKv, _miner, _encodedSamples[i], _masks[i], _inclusiveProofs[i], _decodeProof[i]
-                ),
-                "EthStorageContract: invalid samples"
-            );
-            _hash0 = keccak256(abi.encode(_hash0, _encodedSamples[i]));
-        }
-        return _hash0;
     }
 
     /// @notice Write a large value to KV store.  If the KV pair exists, overrides it.

--- a/contracts/EthStorageContract1.sol
+++ b/contracts/EthStorageContract1.sol
@@ -1,0 +1,97 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.8.28;
+
+import "./EthStorageContract.sol";
+import "./zk-verify/Decoder.sol";
+
+/// @custom:proxied
+/// @title EthStorageContract1
+/// @notice EthStorage Contract that verifies sample decodings per zk proof
+contract EthStorageContract1 is EthStorageContract, Decoder {
+    /// @notice Constructs the EthStorageContract1 contract.
+    constructor(Config memory _config, uint256 _startTime, uint256 _storageCost, uint256 _dcfFactor)
+        EthStorageContract(_config, _startTime, _storageCost, _dcfFactor)
+    {}
+
+    /// @notice Verify the mask is correct
+    /// @param _proof The ZK proof
+    /// @param _encodingKey The encoding key
+    /// @param _sampleIdxInKv The sample index in the KV
+    /// @param _mask The mask of the sample
+    /// @return The result of the verification
+    function decodeSample(Proof memory _proof, uint256 _encodingKey, uint256 _sampleIdxInKv, uint256 _mask)
+        public
+        view
+        returns (bool)
+    {
+        uint256 xBn254 = _modExp(RU_BN254, _sampleIdxInKv, MODULUS_BN254);
+
+        uint256[] memory input = new uint256[](3);
+        // TODO: simple hash to curve mapping
+        input[0] = _encodingKey % MODULUS_BN254;
+        input[1] = xBn254;
+        input[2] = _mask;
+        return (verifyDecoding(input, _proof) == 0);
+    }
+
+    /// @notice Decode the sample and check the decoded sample is included in the BLOB corresponding to on-chain datahashes
+    /// @param _kvIdx The index of the KV pair
+    /// @param _sampleIdxInKv The sample index in the KV
+    /// @param _miner The miner address
+    /// @param _encodedData The encoded sample data
+    /// @param _mask The mask of the sample
+    /// @param _inclusiveProof The inclusive proof
+    /// @param _decodeProof The decode proof
+    /// @return The result of the check
+    function decodeAndCheckInclusive(
+        uint256 _kvIdx,
+        uint256 _sampleIdxInKv,
+        address _miner,
+        bytes32 _encodedData,
+        uint256 _mask,
+        bytes calldata _inclusiveProof,
+        bytes calldata _decodeProof
+    ) public view virtual returns (bool) {
+        PhyAddr memory kvInfo = kvMap[idxMap[_kvIdx]];
+        Proof memory proof = abi.decode(_decodeProof, (Proof));
+        // BLOB decoding check
+        if (!decodeSample(proof, uint256(keccak256(abi.encode(kvInfo.hash, _miner, _kvIdx))), _sampleIdxInKv, _mask)) {
+            return false;
+        }
+
+        // Inclusive proof of decodedData = mask ^ encodedData
+        return checkInclusive(kvInfo.hash, _sampleIdxInKv, _mask ^ uint256(_encodedData), _inclusiveProof);
+    }
+
+    /// @inheritdoc StorageContract
+    function verifySamples(
+        uint256 _startShardId,
+        bytes32 _hash0,
+        address _miner,
+        bytes32[] memory _encodedSamples,
+        uint256[] memory _masks,
+        bytes[] calldata _inclusiveProofs,
+        bytes[] calldata _decodeProof
+    ) public view virtual override returns (bytes32) {
+        require(_encodedSamples.length == RANDOM_CHECKS, "EthStorageContract1: data length mismatch");
+        require(_masks.length == RANDOM_CHECKS, "EthStorageContract1: masks length mismatch");
+        require(_inclusiveProofs.length == RANDOM_CHECKS, "EthStorageContract1: proof length mismatch");
+        require(_decodeProof.length == RANDOM_CHECKS, "EthStorageContract1: decodeProof length mismatch");
+
+        // calculate the number of samples range of the sample check
+        uint256 rows = 1 << (SHARD_ENTRY_BITS + SAMPLE_LEN_BITS);
+
+        for (uint256 i = 0; i < RANDOM_CHECKS; i++) {
+            (uint256 kvIdx, uint256 sampleIdxInKv) = getSampleIdx(rows, _startShardId, _hash0);
+
+            require(
+                decodeAndCheckInclusive(
+                    kvIdx, sampleIdxInKv, _miner, _encodedSamples[i], _masks[i], _inclusiveProofs[i], _decodeProof[i]
+                ),
+                "EthStorageContract1: invalid samples"
+            );
+            _hash0 = keccak256(abi.encode(_hash0, _encodedSamples[i]));
+        }
+        return _hash0;
+    }
+}

--- a/contracts/EthStorageContract2.sol
+++ b/contracts/EthStorageContract2.sol
@@ -42,7 +42,7 @@ contract EthStorageContract2 is EthStorageContract, Decoder2 {
     /// @param _miner The miner address
     /// @param _decodeProof The zk proof for two sample decoding
     /// @return true if the proof is valid, false otherwise
-    function decodeSample(
+    function decodeSamples(
         uint256[] memory _masks,
         uint256[] memory _kvIdxs,
         uint256[] memory _sampleIdxs,
@@ -92,7 +92,7 @@ contract EthStorageContract2 is EthStorageContract, Decoder2 {
         return (_hash0, kvIdx, sampleIdxInKv);
     }
 
-    /// @inheritdoc EthStorageContract
+    /// @inheritdoc StorageContract
     function verifySamples(
         uint256 _startShardId,
         bytes32 _hash0,
@@ -116,7 +116,9 @@ contract EthStorageContract2 is EthStorageContract, Decoder2 {
                 _checkSample(_startShardId, rows, _hash0, _encodedSamples[i], _masks[i], _inclusiveProofs[i]);
         }
 
-        require(decodeSample(_masks, kvIdxs, sampleIdxs, _miner, _decodeProof[0]), "EthStorageContract2: decode failed");
+        require(
+            decodeSamples(_masks, kvIdxs, sampleIdxs, _miner, _decodeProof[0]), "EthStorageContract2: decode failed"
+        );
         return _hash0;
     }
 }

--- a/contracts/EthStorageContract2.sol
+++ b/contracts/EthStorageContract2.sol
@@ -27,7 +27,7 @@ contract EthStorageContract2 is EthStorageContract, Decoder2 {
     /// @param _decodeProof The zk proof for multiple sample decoding
     /// @param _pubSignals The public signals for the zk proof
     /// @return true if the proof is valid, false otherwise
-    function _decodeSample(bytes calldata _decodeProof, uint256[6] memory _pubSignals) internal view returns (bool) {
+    function _decodeSamples(bytes calldata _decodeProof, uint256[6] memory _pubSignals) internal view returns (bool) {
         (uint256[2] memory pA, uint256[2][2] memory pB, uint256[2] memory pC) =
             abi.decode(_decodeProof, (uint256[2], uint256[2][2], uint256[2]));
         // verifyProof uses the opcode 'return', so if we call verifyProof directly, it will lead to a compiler warning about 'unreachable code'
@@ -49,7 +49,7 @@ contract EthStorageContract2 is EthStorageContract, Decoder2 {
         address _miner,
         bytes calldata _decodeProof
     ) public view returns (bool) {
-        return _decodeSample(
+        return _decodeSamples(
             _decodeProof,
             [
                 _getEncodingKey(_kvIdxs[0], _miner),

--- a/contracts/test/TestEthStorageContract.sol
+++ b/contracts/test/TestEthStorageContract.sol
@@ -1,10 +1,10 @@
 // SPDX-License-Identifier: MIT
 pragma solidity 0.8.28;
 
-import "../EthStorageContract.sol";
+import "../EthStorageContract1.sol";
 import "../libraries/MerkleLib.sol";
 
-contract TestEthStorageContract is EthStorageContract {
+contract TestEthStorageContract is EthStorageContract1 {
     uint256 public currentTimestamp;
 
     struct MerkleProof {
@@ -14,7 +14,7 @@ contract TestEthStorageContract is EthStorageContract {
     }
 
     constructor(Config memory _config, uint256 _startTime, uint256 _storageCost, uint256 _dcfFactor)
-        EthStorageContract(_config, _startTime, _storageCost, _dcfFactor)
+        EthStorageContract1(_config, _startTime, _storageCost, _dcfFactor)
     {}
 
     function setTimestamp(uint256 ts) public {

--- a/scripts/deploy.js
+++ b/scripts/deploy.js
@@ -37,6 +37,8 @@ async function deployContract() {
   treasuryAddress = deployer.address;
 
   const StorageContract = await hre.ethers.getContractFactory("TestEthStorageContractKZG");
+  const bytecode = require('../artifacts/contracts/test/TestEthStorageContractKZG.sol/TestEthStorageContractKZG.json').deployedBytecode;
+  console.log('Runtime bytecode length (bytes):', bytecode.length / 2 - 1);
   // refer to https://docs.google.com/spreadsheets/d/11DHhSang1UZxIFAKYw6_Qxxb-V40Wh1lsYjY2dbIP5k/edit#gid=0
   const implContract = await StorageContract.deploy(
     config,

--- a/scripts/deployL2.js
+++ b/scripts/deployL2.js
@@ -38,6 +38,8 @@ async function deployContract() {
   treasuryAddress = deployer.address;
 
   const StorageContract = await hre.ethers.getContractFactory("EthStorageContractL2");
+  const bytecode = require('../artifacts/contracts/EthStorageContractL2.sol/EthStorageContractL2.json').deployedBytecode;
+  console.log('Runtime bytecode length (bytes):', bytecode.length / 2 - 1);
   // refer to https://docs.google.com/spreadsheets/d/11DHhSang1UZxIFAKYw6_Qxxb-V40Wh1lsYjY2dbIP5k/edit#gid=0
   const implContract = await StorageContract.deploy(
     config,


### PR DESCRIPTION
The runtime bytecode size of `EthStorageContractL2` before this change was 24,199 bytes, which is close to the EIP-170 limit. This constraint prevents the addition of new features, such as a whitelist.

To address this, the `verifySamples` function has been moved from `EthStorageContract` to a new contract called `EthStorageContract1`. As a result, `EthStorageContract2` no longer includes the `Decoder` component which is relatively large but of no use to `EthStorageContract2`.

After implementing this change, the runtime bytecode size of `EthStorageContractL2` has been reduced to 19,616 bytes. Similarly, the size of `TestEthStorageContractKZG` has decreased from 23,512 bytes to 18,929 bytes.

Tested L2 mining with es-node/integration_tests/run_tests.sh and L1 mining with a standalone es-node, both can submit mining tx successfully.
