### PR TITLE
Using EIP-7201

### DIFF
--- a/contracts/DecentralizedKV.sol
+++ b/contracts/DecentralizedKV.sol
@@ -27,6 +27,23 @@ contract DecentralizedKV is AccessControlUpgradeable {
     /// @notice Thrown when the data is not exist.
     error DecentralizedKV_DataNotExist();
 
+    /// @notice The maximum value of optimization blob storage content. It can store 3068 bytes more data than standard blob.
+    /// https://github.com/ethereum-optimism/optimism/blob/develop/op-service/eth/blob.go#L16
+    uint256 internal constant MAX_OPTIMISM_BLOB_DATA_SIZE = (4 * 31 + 3) * 1024 - 4;
+
+    /// @notice Upfront storage cost (pre-dcf)
+    uint256 internal immutable STORAGE_COST;
+
+    /// @notice Discounted cash flow factor in seconds
+    ///         E.g., 0.85 yearly discount in second = 0.9999999948465585 = 340282365167313208607671216367074279424 in Q128.128
+    uint256 internal immutable DCF_FACTOR;
+
+    /// @notice The start time of the storage payment
+    uint256 internal immutable START_TIME;
+
+    /// @notice Maximum size of a single key-value pair
+    uint256 internal immutable MAX_KV_SIZE;
+
     /// @notice Represents the metadata of the key-value .
     /// @custom:field kvIdx  Internal address seeking.
     /// @custom:field kvSize BLOB size.
@@ -47,43 +64,30 @@ contract DecentralizedKV is AccessControlUpgradeable {
         OptimismCompact
     }
 
-    /// @notice The maximum value of optimization blob storage content. It can store 3068 bytes more data than standard blob.
-    /// https://github.com/ethereum-optimism/optimism/blob/develop/op-service/eth/blob.go#L16
-    uint256 internal constant MAX_OPTIMISM_BLOB_DATA_SIZE = (4 * 31 + 3) * 1024 - 4;
+    /// @custom:storage-location erc7201:openzeppelin.storage.DecentralizedKV
+    struct DecentralizedKVStorage {
+        /// @notice The number of entries in the store
+        uint40 _kvEntryCount;
+        /// @notice skey and PhyAddr mapping
+        mapping(bytes32 => PhyAddr) _kvMap;
+        /// @notice index and skey mapping, reverse lookup
+        mapping(uint256 => bytes32) _idxMap;
+    }
 
-    /// @notice Upfront storage cost (pre-dcf)
-    uint256 internal immutable STORAGE_COST;
+    // keccak256(abi.encode(uint256(keccak256("openzeppelin.storage.DecentralizedKV")) - 1)) & ~bytes32(uint256(0xff))
+    bytes32 private constant DecentralizedKVStorageLocation =
+        0xdddbcfdf01968304fa73e5ba952efaf0203fd233c51e4f58b8a185ceb1c2a300;
 
-    /// @notice Discounted cash flow factor in seconds
-    ///         E.g., 0.85 yearly discount in second = 0.9999999948465585 = 340282365167313208607671216367074279424 in Q128.128
-    uint256 internal immutable DCF_FACTOR;
-
-    /// @notice The start time of the storage payment
-    uint256 internal immutable START_TIME;
-
-    /// @notice Maximum size of a single key-value pair
-    uint256 internal immutable MAX_KV_SIZE;
-
-    /// @custom:legacy
-    /// @custom:spacer storageCost, dcfFactor, startTime, maxKvSize
-    /// @notice Spacer for backwards compatibility.
-    uint256[4] private kvSpacers;
-
-    /// @notice The number of entries in the store
-    uint40 public kvEntryCount;
-
-    /// @notice skey and PhyAddr mapping
-    mapping(bytes32 => PhyAddr) internal kvMap;
-
-    /// @notice index and skey mapping, reverse lookup
-    mapping(uint256 => bytes32) internal idxMap;
+    function _getDecentralizedKVStorage() private pure returns (DecentralizedKVStorage storage $) {
+        assembly {
+            $.slot := DecentralizedKVStorageLocation
+        }
+    }
 
     /// @notice Emitted when a key-value is removed.
     /// @param kvIdx        The removed key-value index.
     /// @param kvEntryCount The key-value entry count after removing the kvIdx.
     event Remove(uint256 indexed kvIdx, uint256 indexed kvEntryCount);
-
-    // TODO: Reserve extra slots (to a total of 50?) in the storage layout for future upgrades
 
     /// @notice Constructs the DecentralizedKV contract. Initializes the immutables.
     constructor(uint256 _maxKvSize, uint256 _startTime, uint256 _storageCost, uint256 _dcfFactor) {
@@ -99,7 +103,9 @@ contract DecentralizedKV is AccessControlUpgradeable {
         __Context_init();
         __AccessControl_init();
         _grantRole(DEFAULT_ADMIN_ROLE, _owner);
-        kvEntryCount = 0;
+
+        DecentralizedKVStorage storage $ = _getDecentralizedKVStorage();
+        $._kvEntryCount = 0;
     }
 
     /// @notice Pow function in Q128.
@@ -158,22 +164,24 @@ contract DecentralizedKV is AccessControlUpgradeable {
             }
         }
 
+        DecentralizedKVStorage storage $ = _getDecentralizedKVStorage();
+
         uint256[] memory res = new uint256[](keysLength);
         uint256 batchPaymentSize = 0;
         for (uint256 i = 0; i < keysLength; i++) {
             bytes32 skey = keccak256(abi.encode(msg.sender, _keys[i]));
-            PhyAddr memory paddr = kvMap[skey];
+            PhyAddr memory paddr = $._kvMap[skey];
 
             if (paddr.hash == 0) {
                 // append (require payment from sender)
                 batchPaymentSize++;
-                paddr.kvIdx = kvEntryCount;
-                idxMap[paddr.kvIdx] = skey;
-                kvEntryCount = kvEntryCount + 1;
+                paddr.kvIdx = $._kvEntryCount;
+                $._idxMap[paddr.kvIdx] = skey;
+                $._kvEntryCount = $._kvEntryCount + 1;
             }
             paddr.kvSize = uint24(_lengths[i]);
             paddr.hash = bytes24(_dataHashes[i]);
-            kvMap[skey] = paddr;
+            $._kvMap[skey] = paddr;
 
             res[i] = paddr.kvIdx;
         }
@@ -189,19 +197,22 @@ contract DecentralizedKV is AccessControlUpgradeable {
     /// @notice Return the size of the keyed value.
     function size(bytes32 _key) public view returns (uint256) {
         bytes32 skey = keccak256(abi.encode(msg.sender, _key));
-        return kvMap[skey].kvSize;
+        DecentralizedKVStorage storage $ = _getDecentralizedKVStorage();
+        return $._kvMap[skey].kvSize;
     }
 
     /// @notice Return the dataHash of the keyed value.
     function hash(bytes32 _key) public view returns (bytes24) {
         bytes32 skey = keccak256(abi.encode(msg.sender, _key));
-        return kvMap[skey].hash;
+        DecentralizedKVStorage storage $ = _getDecentralizedKVStorage();
+        return $._kvMap[skey].hash;
     }
 
     /// @notice Check if the key-value exists.
     function exist(bytes32 _key) public view returns (bool) {
         bytes32 skey = keccak256(abi.encode(msg.sender, _key));
-        return kvMap[skey].hash != 0;
+        DecentralizedKVStorage storage $ = _getDecentralizedKVStorage();
+        return $._kvMap[skey].hash != 0;
     }
 
     // @notice Return the keyed data given off and len.  This function can be only called in JSON-RPC context of ES L2 node.
@@ -221,7 +232,8 @@ contract DecentralizedKV is AccessControlUpgradeable {
         }
 
         bytes32 skey = keccak256(abi.encode(msg.sender, _key));
-        PhyAddr memory paddr = kvMap[skey];
+        DecentralizedKVStorage storage $ = _getDecentralizedKVStorage();
+        PhyAddr memory paddr = $._kvMap[skey];
 
         if (paddr.hash == 0) {
             revert DecentralizedKV_DataNotExist();
@@ -281,8 +293,9 @@ contract DecentralizedKV is AccessControlUpgradeable {
         uint256 kvIndicesLength = _kvIndices.length;
 
         bytes32[] memory res = new bytes32[](kvIndicesLength);
+        DecentralizedKVStorage storage $ = _getDecentralizedKVStorage();
         for (uint256 i = 0; i < kvIndicesLength; i++) {
-            PhyAddr memory paddr = kvMap[idxMap[_kvIndices[i]]];
+            PhyAddr memory paddr = $._kvMap[$._idxMap[_kvIndices[i]]];
 
             res[i] |= bytes32(uint256(_kvIndices[i])) << 216;
             res[i] |= bytes32(uint256(paddr.kvSize)) << 192;
@@ -292,9 +305,40 @@ contract DecentralizedKV is AccessControlUpgradeable {
         return res;
     }
 
-    /// @notice This is for compatibility with earlier versions and can be removed in the future.
-    function lastKvIdx() public view returns (uint40) {
-        return kvEntryCount;
+    /// @notice Getter for kvEntryCount
+    function kvEntryCount() public view returns (uint40) {
+        DecentralizedKVStorage storage $ = _getDecentralizedKVStorage();
+        return $._kvEntryCount;
+    }
+
+    /// @notice Setter for kvEntryCount
+    function _setKvEntryCount(uint40 _value) internal {
+        DecentralizedKVStorage storage $ = _getDecentralizedKVStorage();
+        $._kvEntryCount = _value;
+    }
+
+    /// @notice Getter for kvMap
+    function _kvMap(bytes32 _key) internal view returns (PhyAddr memory) {
+        DecentralizedKVStorage storage $ = _getDecentralizedKVStorage();
+        return $._kvMap[_key];
+    }
+
+    /// @notice Setter for kvMap
+    function _setKvMap(bytes32 _key, PhyAddr memory _value) internal {
+        DecentralizedKVStorage storage $ = _getDecentralizedKVStorage();
+        $._kvMap[_key] = _value;
+    }
+
+    /// @notice Getter for idxMap
+    function _idxMap(uint256 _kvIdx) internal view returns (bytes32) {
+        DecentralizedKVStorage storage $ = _getDecentralizedKVStorage();
+        return $._idxMap[_kvIdx];
+    }
+
+    /// @notice Setter for idxMap
+    function _setIdxMap(uint256 _kvIdx, bytes32 _value) internal {
+        DecentralizedKVStorage storage $ = _getDecentralizedKVStorage();
+        $._idxMap[_kvIdx] = _value;
     }
 
     /// @notice Getter for STORAGE_COST

--- a/contracts/EthStorageContract.sol
+++ b/contracts/EthStorageContract.sol
@@ -31,8 +31,8 @@ abstract contract EthStorageContract is StorageContract, ISemver {
     uint256 constant FIELD_ELEMENTS_PER_BLOB = 0x1000;
 
     /// @notice Semantic version.
-    /// @custom:semver 0.1.2
-    string public constant version = "0.1.2";
+    /// @custom:semver 0.2.0
+    string public constant version = "0.2.0";
 
     // TODO: Reserve extra slots (to a total of 50?) in the storage layout for future upgrades
 

--- a/contracts/EthStorageContract.sol
+++ b/contracts/EthStorageContract.sol
@@ -92,7 +92,7 @@ abstract contract EthStorageContract is StorageContract, ISemver {
 
     /// @notice Compute the encoding key using the kvIdx and miner address
     function _getEncodingKey(uint256 _kvIdx, address _miner) internal view returns (uint256) {
-        return uint256(keccak256(abi.encode(kvMap[idxMap[_kvIdx]].hash, _miner, _kvIdx))) % MODULUS_BN254;
+        return uint256(keccak256(abi.encode(_kvMap(_idxMap(_kvIdx)).hash, _miner, _kvIdx))) % MODULUS_BN254;
     }
 
     /// @notice Compute the input X for inclusion proof using the sample index

--- a/contracts/EthStorageContractM1.sol
+++ b/contracts/EthStorageContractM1.sol
@@ -76,7 +76,7 @@ contract EthStorageContractM1 is EthStorageContract, Decoder {
             // Inclusive proof of decodedData = mask ^ encodedData
             if (
                 !checkInclusive(
-                    kvMap[idxMap[kvIdx]].hash,
+                    _kvMap(_idxMap(kvIdx)).hash,
                     sampleIdxInKv,
                     _masks[i] ^ uint256(_encodedSamples[i]),
                     _inclusiveProofs[i]

--- a/contracts/EthStorageContractM1L2.sol
+++ b/contracts/EthStorageContractM1L2.sol
@@ -22,7 +22,7 @@ contract EthStorageContractM1L2 is EthStorageContractM1, L2Base {
 
     /// @inheritdoc StorageContract
     function _checkAppend(uint256 _batchSize) internal virtual override {
-        uint256 kvEntryCountPrev = kvEntryCount - _batchSize; // kvEntryCount already increased
+        uint256 kvEntryCountPrev = kvEntryCount() - _batchSize; // kvEntryCount already increased
         uint256 totalPayment = _upfrontPaymentInBatch(kvEntryCountPrev, _batchSize);
         uint256 sgtCharged = 0;
         if (soulGasToken != address(0)) {
@@ -32,7 +32,7 @@ contract EthStorageContractM1L2 is EthStorageContractM1, L2Base {
             revert EthStorageContractM1L2_NotEnoughPayment();
         }
 
-        uint256 shardId = _getShardId(kvEntryCount); // shard id after the batch
+        uint256 shardId = _getShardId(kvEntryCount()); // shard id after the batch
         if (shardId > _getShardId(kvEntryCountPrev)) {
             // Open a new shard and mark the shard is ready to mine.
             infos[shardId].lastMineTime = _blockTs();

--- a/contracts/EthStorageContractM1L2.sol
+++ b/contracts/EthStorageContractM1L2.sol
@@ -35,7 +35,11 @@ contract EthStorageContractM1L2 is EthStorageContractM1, L2Base {
         uint256 shardId = _getShardId(kvEntryCount()); // shard id after the batch
         if (shardId > _getShardId(kvEntryCountPrev)) {
             // Open a new shard and mark the shard is ready to mine.
-            infos[shardId].lastMineTime = _blockTs();
+            (, uint256 difficulty, uint256 blockMined) = infos(shardId);
+            setMiningInfo(
+                shardId,
+                MiningLib.MiningInfo({lastMineTime: _blockTs(), difficulty: difficulty, blockMined: blockMined})
+            );
         }
     }
 

--- a/contracts/EthStorageContractM1L2.sol
+++ b/contracts/EthStorageContractM1L2.sol
@@ -25,8 +25,8 @@ contract EthStorageContractM1L2 is EthStorageContractM1, L2Base {
         uint256 kvEntryCountPrev = kvEntryCount() - _batchSize; // kvEntryCount already increased
         uint256 totalPayment = _upfrontPaymentInBatch(kvEntryCountPrev, _batchSize);
         uint256 sgtCharged = 0;
-        if (soulGasToken != address(0)) {
-            sgtCharged = ISoulGasToken(soulGasToken).chargeFromOrigin(totalPayment);
+        if (soulGasToken() != address(0)) {
+            sgtCharged = ISoulGasToken(soulGasToken()).chargeFromOrigin(totalPayment);
         }
         if (msg.value < totalPayment - sgtCharged) {
             revert EthStorageContractM1L2_NotEnoughPayment();

--- a/contracts/EthStorageContractM2.sol
+++ b/contracts/EthStorageContractM2.sol
@@ -71,7 +71,7 @@ contract EthStorageContractM2 is EthStorageContract, Decoder2 {
     ) internal view returns (bytes32, uint256, uint256) {
         (uint256 kvIdx, uint256 sampleIdxInKv) = getSampleIdx(_rows, _startShardId, _hash0);
 
-        PhyAddr memory kvInfo = kvMap[idxMap[kvIdx]];
+        PhyAddr memory kvInfo = _kvMap(_idxMap(kvIdx));
 
         if (!checkInclusive(kvInfo.hash, sampleIdxInKv, _mask ^ uint256(_encodedSample), _inclusiveProof)) {
             revert EthStorageContractM2_InvalidSamples();

--- a/contracts/EthStorageContractM2L2.sol
+++ b/contracts/EthStorageContractM2L2.sol
@@ -22,7 +22,7 @@ contract EthStorageContractM2L2 is EthStorageContractM2, L2Base {
 
     /// @inheritdoc StorageContract
     function _checkAppend(uint256 _batchSize) internal virtual override {
-        uint256 kvEntryCountPrev = kvEntryCount - _batchSize; // kvEntryCount already increased
+        uint256 kvEntryCountPrev = kvEntryCount() - _batchSize; // kvEntryCount already increased
         uint256 totalPayment = _upfrontPaymentInBatch(kvEntryCountPrev, _batchSize);
         uint256 sgtCharged = 0;
         if (soulGasToken != address(0)) {
@@ -33,7 +33,7 @@ contract EthStorageContractM2L2 is EthStorageContractM2, L2Base {
             revert EthStorageContractM2L2_NotEnoughPayment();
         }
 
-        uint256 shardId = _getShardId(kvEntryCount); // shard id after the batch
+        uint256 shardId = _getShardId(kvEntryCount()); // shard id after the batch
         if (shardId > _getShardId(kvEntryCountPrev)) {
             // Open a new shard and mark the shard is ready to mine.
             infos[shardId].lastMineTime = _blockTs();

--- a/contracts/EthStorageContractM2L2.sol
+++ b/contracts/EthStorageContractM2L2.sol
@@ -25,8 +25,8 @@ contract EthStorageContractM2L2 is EthStorageContractM2, L2Base {
         uint256 kvEntryCountPrev = kvEntryCount() - _batchSize; // kvEntryCount already increased
         uint256 totalPayment = _upfrontPaymentInBatch(kvEntryCountPrev, _batchSize);
         uint256 sgtCharged = 0;
-        if (soulGasToken != address(0)) {
-            sgtCharged = ISoulGasToken(soulGasToken).chargeFromOrigin(totalPayment);
+        if (soulGasToken() != address(0)) {
+            sgtCharged = ISoulGasToken(soulGasToken()).chargeFromOrigin(totalPayment);
         }
 
         if (msg.value < totalPayment - sgtCharged) {

--- a/contracts/EthStorageContractM2L2.sol
+++ b/contracts/EthStorageContractM2L2.sol
@@ -36,7 +36,11 @@ contract EthStorageContractM2L2 is EthStorageContractM2, L2Base {
         uint256 shardId = _getShardId(kvEntryCount()); // shard id after the batch
         if (shardId > _getShardId(kvEntryCountPrev)) {
             // Open a new shard and mark the shard is ready to mine.
-            infos[shardId].lastMineTime = _blockTs();
+            (, uint256 difficulty, uint256 blockMined) = infos(shardId);
+            setMiningInfo(
+                shardId,
+                MiningLib.MiningInfo({lastMineTime: _blockTs(), difficulty: difficulty, blockMined: blockMined})
+            );
         }
     }
 

--- a/contracts/test/TestEthStorageContractM1.sol
+++ b/contracts/test/TestEthStorageContractM1.sol
@@ -185,7 +185,7 @@ contract TestEthStorageContractM1 is EthStorageContractM1 {
         uint256 mineTs = _getMinedTs(blockNumber);
 
         // Given a blockhash and a miner, we only allow sampling up to nonce limit times.
-        require(nonce < nonceLimit, "nonce too big");
+        require(nonce < nonceLimit(), "nonce too big");
 
         // Check if the data matches the hash in metadata and obtain the solution hash.
         hash0 = keccak256(abi.encode(miner, hash0, nonce));
@@ -226,7 +226,7 @@ contract TestEthStorageContractM1 is EthStorageContractM1 {
         uint256 mineTs = block.timestamp;
 
         // Given a blockhash and a miner, we only allow sampling up to nonce limit times.
-        require(nonce < nonceLimit, "nonce too big");
+        require(nonce < nonceLimit(), "nonce too big");
 
         // Check if the data matches the hash in metadata and obtain the solution hash.
         verifySamples(shardId, initHash0, miner, encodedSamples, masks, inclusiveProofs, decodeProof);

--- a/contracts/test/TestEthStorageContractM1.sol
+++ b/contracts/test/TestEthStorageContractM1.sol
@@ -74,7 +74,7 @@ contract TestEthStorageContractM1 is EthStorageContractM1 {
     }
 
     function getEncodingKey(uint256 kvIdx, address miner) public view returns (bytes32) {
-        return keccak256(abi.encode(kvMap[idxMap[kvIdx]].hash, miner, kvIdx));
+        return keccak256(abi.encode(_kvMap(_idxMap(kvIdx)).hash, miner, kvIdx));
     }
 
     /// @notice Verify the mask is correct

--- a/contracts/test/TestEthStorageContractM2L2.sol
+++ b/contracts/test/TestEthStorageContractM2L2.sol
@@ -14,12 +14,12 @@ contract TestEthStorageContractM2L2 is EthStorageContractM2L2 {
 
     /// @notice Get the number of blobs updated within the current block.
     function getBlobsUpdated() public view returns (uint256) {
-        return updateState & type(uint32).max;
+        return updateState() & type(uint32).max;
     }
 
     /// @notice Get the block number of the last update.
     function getBlockLastUpdate() public view returns (uint256) {
-        return updateState >> 32;
+        return updateState() >> 32;
     }
 
     function _blockNumber() internal view virtual override returns (uint256) {

--- a/contracts/test/TestStorageContract.sol
+++ b/contracts/test/TestStorageContract.sol
@@ -31,7 +31,7 @@ contract TestStorageContract is StorageContract {
     }
 
     function setKvEntryCount(uint40 _kvEntryCount) public {
-        kvEntryCount = _kvEntryCount;
+        _setKvEntryCount(_kvEntryCount);
     }
 
     function paymentIn(uint256 _x, uint256 _fromTs, uint256 _toTs) public view returns (uint256) {


### PR DESCRIPTION
Fix https://github.com/ethstorage/storage-contracts-v1/issues/130

### Code changes
 - Applied EIP-7201 storage layout to `DecentralizedKV.sol`, `StorageContract`, and `L2Base`
 - Removed legacy spacer variables and reserved slots. Please note that **this change is not storage-compatible with previous versions.**
 - Removed lastKvIdx(); use kvEntryCount() instead, @syntrust please update es-node accordingly..
 - Kept `locked` in StorageContract as a standalone slot since it must be declared as a transient type.

### Tests passed
- Unit tests with mode1 proof mining:

```bash
python3 -m venv myenv
source myenv/bin/activate
export G16_WASM_PATH=/path/blob_poseidon.wasm
export G16_ZKEY_PATH=/path/blob_poseidon.zkey
npm run test
```
