### PR TITLE
Disable forge lint when using forge 1.3.1

### DIFF
--- a/foundry.lock
+++ b/foundry.lock
@@ -1,0 +1,14 @@
+{
+  "lib/openzeppelin-contracts-upgradeable": {
+    "rev": "e725abddf1e01cf05ace496e950fc8e243cc7cab"
+  },
+  "lib/ds-test": {
+    "rev": "e282159d5170298eb2455a6c05280ab5a73a4ef0"
+  },
+  "lib/forge-std": {
+    "rev": "3b20d60d14b343ee4f908cb8079495c07f5e8981"
+  },
+  "lib/openzeppelin-foundry-upgrades": {
+    "rev": "cbce1e00305e943aa1661d43f41e5ac72c662b07"
+  }
+}

--- a/foundry.toml
+++ b/foundry.toml
@@ -16,3 +16,7 @@ fs_permissions = [
 ]
 optimizer = true
 optimizer_runs = 200
+
+[lint]
+severity = ["high"]
+exclude_lints = ["incorrect-shift"]


### PR DESCRIPTION
Temporarily disable Forge lint (introduced in 1.3.1); plan to re-enable after resolving warnings