### PR TITLE
fix lint of info level severity

### DIFF
--- a/contracts/DecentralizedKV.sol
+++ b/contracts/DecentralizedKV.sol
@@ -1,8 +1,8 @@
 // SPDX-License-Identifier: MIT
 pragma solidity 0.8.28;
 
-import "@openzeppelin/contracts-upgradeable/proxy/utils/Initializable.sol";
-import "./libraries/BinaryRelated.sol";
+import {Initializable} from "@openzeppelin/contracts-upgradeable/proxy/utils/Initializable.sol";
+import {BinaryRelated} from "./libraries/BinaryRelated.sol";
 
 /// @custom:upgradeable
 /// @title DecentralizedKV
@@ -72,7 +72,7 @@ contract DecentralizedKV is Initializable {
     }
 
     /// @custom:storage-location erc7201:openzeppelin.storage.DecentralizedKV
-    struct DecentralizedKVStorage {
+    struct DecentralizedKvStorage {
         /// @notice The number of entries in the store
         uint40 _kvEntryCount;
         /// @notice skey and PhyAddr mapping
@@ -82,12 +82,12 @@ contract DecentralizedKV is Initializable {
     }
 
     // keccak256(abi.encode(uint256(keccak256("openzeppelin.storage.DecentralizedKV")) - 1)) & ~bytes32(uint256(0xff))
-    bytes32 private constant DecentralizedKVStorageLocation =
+    bytes32 private constant DECENTRALIZED_KV_STORAGE_LOCATION =
         0xdddbcfdf01968304fa73e5ba952efaf0203fd233c51e4f58b8a185ceb1c2a300;
 
-    function _getDecentralizedKVStorage() private pure returns (DecentralizedKVStorage storage $) {
+    function _getDecentralizedKvStorage() private pure returns (DecentralizedKvStorage storage $) {
         assembly {
-            $.slot := DecentralizedKVStorageLocation
+            $.slot := DECENTRALIZED_KV_STORAGE_LOCATION
         }
     }
 
@@ -106,8 +106,8 @@ contract DecentralizedKV is Initializable {
     }
 
     /// @notice Initializer.
-    function __init_KV() internal onlyInitializing {
-        DecentralizedKVStorage storage $ = _getDecentralizedKVStorage();
+    function initKv() internal onlyInitializing {
+        DecentralizedKvStorage storage $ = _getDecentralizedKvStorage();
         $._kvEntryCount = 0;
     }
 
@@ -167,7 +167,7 @@ contract DecentralizedKV is Initializable {
             }
         }
 
-        DecentralizedKVStorage storage $ = _getDecentralizedKVStorage();
+        DecentralizedKvStorage storage $ = _getDecentralizedKvStorage();
 
         uint256[] memory res = new uint256[](keysLength);
         uint256 batchPaymentSize = 0;
@@ -202,21 +202,21 @@ contract DecentralizedKV is Initializable {
     /// @notice Return the size of the keyed value.
     function size(bytes32 _key) public view returns (uint256) {
         bytes32 skey = keccak256(abi.encode(msg.sender, _key));
-        DecentralizedKVStorage storage $ = _getDecentralizedKVStorage();
+        DecentralizedKvStorage storage $ = _getDecentralizedKvStorage();
         return $._kvMap[skey].kvSize;
     }
 
     /// @notice Return the dataHash of the keyed value.
     function hash(bytes32 _key) public view returns (bytes24) {
         bytes32 skey = keccak256(abi.encode(msg.sender, _key));
-        DecentralizedKVStorage storage $ = _getDecentralizedKVStorage();
+        DecentralizedKvStorage storage $ = _getDecentralizedKvStorage();
         return $._kvMap[skey].hash;
     }
 
     /// @notice Check if the key-value exists.
     function exist(bytes32 _key) public view returns (bool) {
         bytes32 skey = keccak256(abi.encode(msg.sender, _key));
-        DecentralizedKVStorage storage $ = _getDecentralizedKVStorage();
+        DecentralizedKvStorage storage $ = _getDecentralizedKvStorage();
         return $._kvMap[skey].hash != 0;
     }
 
@@ -237,7 +237,7 @@ contract DecentralizedKV is Initializable {
         }
 
         bytes32 skey = keccak256(abi.encode(msg.sender, _key));
-        DecentralizedKVStorage storage $ = _getDecentralizedKVStorage();
+        DecentralizedKvStorage storage $ = _getDecentralizedKvStorage();
         PhyAddr memory paddr = $._kvMap[skey];
 
         if (paddr.hash == 0) {
@@ -298,7 +298,7 @@ contract DecentralizedKV is Initializable {
         uint256 kvIndicesLength = _kvIndices.length;
 
         bytes32[] memory res = new bytes32[](kvIndicesLength);
-        DecentralizedKVStorage storage $ = _getDecentralizedKVStorage();
+        DecentralizedKvStorage storage $ = _getDecentralizedKvStorage();
         for (uint256 i = 0; i < kvIndicesLength; i++) {
             PhyAddr memory paddr = $._kvMap[$._idxMap[_kvIndices[i]]];
 
@@ -311,37 +311,37 @@ contract DecentralizedKV is Initializable {
 
     /// @notice Getter for kvEntryCount
     function kvEntryCount() public view returns (uint40) {
-        DecentralizedKVStorage storage $ = _getDecentralizedKVStorage();
+        DecentralizedKvStorage storage $ = _getDecentralizedKvStorage();
         return $._kvEntryCount;
     }
 
     /// @notice Setter for kvEntryCount
     function _setKvEntryCount(uint40 _value) internal {
-        DecentralizedKVStorage storage $ = _getDecentralizedKVStorage();
+        DecentralizedKvStorage storage $ = _getDecentralizedKvStorage();
         $._kvEntryCount = _value;
     }
 
     /// @notice Getter for kvMap
     function _kvMap(bytes32 _key) internal view returns (PhyAddr memory) {
-        DecentralizedKVStorage storage $ = _getDecentralizedKVStorage();
+        DecentralizedKvStorage storage $ = _getDecentralizedKvStorage();
         return $._kvMap[_key];
     }
 
     /// @notice Setter for kvMap
     function _setKvMap(bytes32 _key, PhyAddr memory _value) internal {
-        DecentralizedKVStorage storage $ = _getDecentralizedKVStorage();
+        DecentralizedKvStorage storage $ = _getDecentralizedKvStorage();
         $._kvMap[_key] = _value;
     }
 
     /// @notice Getter for idxMap
     function _idxMap(uint256 _kvIdx) internal view returns (bytes32) {
-        DecentralizedKVStorage storage $ = _getDecentralizedKVStorage();
+        DecentralizedKvStorage storage $ = _getDecentralizedKvStorage();
         return $._idxMap[_kvIdx];
     }
 
     /// @notice Setter for idxMap
     function _setIdxMap(uint256 _kvIdx, bytes32 _value) internal {
-        DecentralizedKVStorage storage $ = _getDecentralizedKVStorage();
+        DecentralizedKvStorage storage $ = _getDecentralizedKvStorage();
         $._idxMap[_kvIdx] = _value;
     }
 

--- a/contracts/DecentralizedKV.sol
+++ b/contracts/DecentralizedKV.sol
@@ -106,7 +106,7 @@ contract DecentralizedKV is Initializable {
     }
 
     /// @notice Initializer.
-    function initKv() internal onlyInitializing {
+    function _initKv() internal onlyInitializing {
         DecentralizedKvStorage storage $ = _getDecentralizedKvStorage();
         $._kvEntryCount = 0;
     }

--- a/contracts/EthStorageContract.sol
+++ b/contracts/EthStorageContract.sol
@@ -163,6 +163,7 @@ abstract contract EthStorageContract is StorageContract, ISemver {
         uint256 parent = uint256(_hash0) % _rows;
         uint256 sampleIdx = parent + (_startShardId << (SHARD_ENTRY_BITS + SAMPLE_LEN_BITS));
         uint256 kvIdx = sampleIdx >> SAMPLE_LEN_BITS;
+        /// forge-lint: disable-next-line(incorrect-shift)
         uint256 sampleIdxInKv = sampleIdx % (1 << SAMPLE_LEN_BITS);
         return (kvIdx, sampleIdxInKv);
     }

--- a/contracts/EthStorageContract.sol
+++ b/contracts/EthStorageContract.sol
@@ -56,7 +56,7 @@ abstract contract EthStorageContract is StorageContract, ISemver {
         address _treasury,
         address _owner
     ) public payable virtual initializer {
-        initStorage(_minimumDiff, _prepaidAmount, _nonceLimit, _treasury, _owner);
+        _initStorage(_minimumDiff, _prepaidAmount, _nonceLimit, _treasury, _owner);
     }
 
     /// @notice Performs modular exponentiation, which is a type of exponentiation performed over a modulus.

--- a/contracts/EthStorageContract.sol
+++ b/contracts/EthStorageContract.sol
@@ -1,9 +1,9 @@
 // SPDX-License-Identifier: MIT
 pragma solidity 0.8.28;
 
-import "./StorageContract.sol";
-import "./libraries//BinaryRelated.sol";
-import "./Interfaces/ISemver.sol";
+import {StorageContract} from "./StorageContract.sol";
+import {BinaryRelated} from "./libraries/BinaryRelated.sol";
+import {ISemver} from "./Interfaces/ISemver.sol";
 
 /// @custom:proxied
 /// @title EthStorageContract
@@ -31,7 +31,7 @@ abstract contract EthStorageContract is StorageContract, ISemver {
     uint256 internal constant FIELD_ELEMENTS_PER_BLOB = 0x1000;
 
     /// @notice Semantic version.
-    /// @custom:semver 0.2.0
+    /// @custom:semver 0.2.1
     string public constant version = "0.2.1";
 
     /// @notice Emitted when a BLOB is appended.
@@ -56,7 +56,7 @@ abstract contract EthStorageContract is StorageContract, ISemver {
         address _treasury,
         address _owner
     ) public payable virtual initializer {
-        __init_storage(_minimumDiff, _prepaidAmount, _nonceLimit, _treasury, _owner);
+        initStorage(_minimumDiff, _prepaidAmount, _nonceLimit, _treasury, _owner);
     }
 
     /// @notice Performs modular exponentiation, which is a type of exponentiation performed over a modulus.

--- a/contracts/EthStorageContract.sol
+++ b/contracts/EthStorageContract.sol
@@ -32,6 +32,7 @@ abstract contract EthStorageContract is StorageContract, ISemver {
 
     /// @notice Semantic version.
     /// @custom:semver 0.2.1
+    ///forge-lint: disable-next-line(screaming-snake-case-const)
     string public constant version = "0.2.1";
 
     /// @notice Emitted when a BLOB is appended.

--- a/contracts/EthStorageContractM1.sol
+++ b/contracts/EthStorageContractM1.sol
@@ -1,8 +1,9 @@
 // SPDX-License-Identifier: MIT
 pragma solidity 0.8.28;
 
-import "./EthStorageContract.sol";
-import "./zk-verify/Decoder.sol";
+import {EthStorageContract} from "./EthStorageContract.sol";
+import {StorageContract} from "./StorageContract.sol";
+import {Decoder} from "./zk-verify/Decoder.sol";
 
 /// @custom:proxied
 /// @title EthStorageContractM1

--- a/contracts/EthStorageContractM1.sol
+++ b/contracts/EthStorageContractM1.sol
@@ -76,6 +76,7 @@ contract EthStorageContractM1 is EthStorageContract, Decoder {
         }
 
         // calculate the number of samples range of the sample check
+        /// forge-lint: disable-next-line(incorrect-shift)
         uint256 rows = 1 << (SHARD_ENTRY_BITS + SAMPLE_LEN_BITS);
 
         for (uint256 i = 0; i < RANDOM_CHECKS; i++) {

--- a/contracts/EthStorageContractM1L2.sol
+++ b/contracts/EthStorageContractM1L2.sol
@@ -1,8 +1,11 @@
 // SPDX-License-Identifier: MIT
 pragma solidity 0.8.28;
 
-import "./EthStorageContractM1.sol";
-import "./L2Base.sol";
+import {MiningLib} from "./libraries/MiningLib.sol";
+import {EthStorageContractM1} from "./EthStorageContractM1.sol";
+import {L2Base, ISoulGasToken} from "./L2Base.sol";
+import {DecentralizedKV} from "./DecentralizedKV.sol";
+import {StorageContract} from "./StorageContract.sol";
 
 /// @custom:proxied
 /// @title EthStorageContractM1L2

--- a/contracts/EthStorageContractM2.sol
+++ b/contracts/EthStorageContractM2.sol
@@ -111,6 +111,7 @@ contract EthStorageContractM2 is EthStorageContract, Decoder2 {
         }
 
         // calculate the number of samples range of the sample check
+        /// forge-lint: disable-next-line(incorrect-shift)
         uint256 rows = 1 << (SHARD_ENTRY_BITS + SAMPLE_LEN_BITS);
 
         uint256[] memory kvIdxs = new uint256[](RANDOM_CHECKS);

--- a/contracts/EthStorageContractM2.sol
+++ b/contracts/EthStorageContractM2.sol
@@ -1,8 +1,9 @@
 // SPDX-License-Identifier: MIT
 pragma solidity 0.8.28;
 
-import "./EthStorageContract.sol";
-import "./zk-verify/Decoder2.sol";
+import {StorageContract} from "./StorageContract.sol";
+import {EthStorageContract} from "./EthStorageContract.sol";
+import {Decoder2} from "./zk-verify/Decoder2.sol";
 
 /// @custom:proxied
 /// @title EthStorageContractM2

--- a/contracts/EthStorageContractM2L2.sol
+++ b/contracts/EthStorageContractM2L2.sol
@@ -1,8 +1,11 @@
 // SPDX-License-Identifier: MIT
 pragma solidity 0.8.28;
 
-import "./EthStorageContractM2.sol";
-import "./L2Base.sol";
+import {EthStorageContractM2} from "./EthStorageContractM2.sol";
+import {L2Base, ISoulGasToken} from "./L2Base.sol";
+import {DecentralizedKV} from "./DecentralizedKV.sol";
+import {StorageContract} from "./StorageContract.sol";
+import {MiningLib} from "./libraries/MiningLib.sol";
 
 /// @custom:proxied
 /// @title EthStorageContractM2L2

--- a/contracts/L2Base.sol
+++ b/contracts/L2Base.sol
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: MIT
 pragma solidity 0.8.28;
 
-import "./libraries/RandaoLib.sol";
+import {RandaoLib} from "./libraries/RandaoLib.sol";
 
 /// @title IL1Block
 /// @notice Interface for L1Block contract.
@@ -55,11 +55,12 @@ abstract contract L2Base {
     }
 
     // keccak256(abi.encode(uint256(keccak256("openzeppelin.storage.L2Base")) - 1)) & ~bytes32(uint256(0xff))
-    bytes32 private constant L2BaseStorageLocation = 0x4f2e75529ec26b25c2fdfe7928382000d9e4289cb7792c1db94ef3c9ffecd900;
+    bytes32 private constant L2_BASE_STORAGE_LOCATION =
+        0x4f2e75529ec26b25c2fdfe7928382000d9e4289cb7792c1db94ef3c9ffecd900;
 
     function _getL2BaseStorage() private pure returns (L2BaseStorage storage $) {
         assembly {
-            $.slot := L2BaseStorageLocation
+            $.slot := L2_BASE_STORAGE_LOCATION
         }
     }
 

--- a/contracts/StorageContract.sol
+++ b/contracts/StorageContract.sol
@@ -1,11 +1,10 @@
 // SPDX-License-Identifier: MIT
 pragma solidity 0.8.28;
 
-import "@openzeppelin/contracts-upgradeable/access/AccessControlUpgradeable.sol";
-
-import "./DecentralizedKV.sol";
-import "./libraries/MiningLib.sol";
-import "./libraries/RandaoLib.sol";
+import {AccessControlUpgradeable} from "@openzeppelin/contracts-upgradeable/access/AccessControlUpgradeable.sol";
+import {DecentralizedKV} from "./DecentralizedKV.sol";
+import {MiningLib} from "./libraries/MiningLib.sol";
+import {RandaoLib} from "./libraries/RandaoLib.sol";
 
 /// @custom:upgradeable
 /// @title StorageContract
@@ -131,12 +130,12 @@ abstract contract StorageContract is DecentralizedKV, AccessControlUpgradeable {
     }
 
     // keccak256(abi.encode(uint256(keccak256("openzeppelin.storage.StorageContract")) - 1)) & ~bytes32(uint256(0xff))
-    bytes32 private constant StorageContractStorageLocation =
+    bytes32 private constant STORAGE_CONTRACT_STORAGE_LOCATION =
         0x2e87afa02c4126794624df6162c63cb642521b7bea4fc2331190b8ab7e6a0f00;
 
     function _getStorageContractStorage() private pure returns (StorageContractStorage storage $) {
         assembly {
-            $.slot := StorageContractStorageLocation
+            $.slot := STORAGE_CONTRACT_STORAGE_LOCATION
         }
     }
 
@@ -204,7 +203,7 @@ abstract contract StorageContract is DecentralizedKV, AccessControlUpgradeable {
     /// @param _nonceLimit    The maximum nonce per block.
     /// @param _treasury      The treasury address.
     /// @param _owner         The contract owner.
-    function __init_storage(
+    function initStorage(
         uint256 _minimumDiff,
         uint256 _prepaidAmount,
         uint256 _nonceLimit,
@@ -214,7 +213,7 @@ abstract contract StorageContract is DecentralizedKV, AccessControlUpgradeable {
         __AccessControl_init();
         _grantRole(DEFAULT_ADMIN_ROLE, _owner);
 
-        __init_KV();
+        initKv();
 
         StorageContractStorage storage $ = _getStorageContractStorage();
         $._minimumDiff = _minimumDiff;

--- a/contracts/StorageContract.sol
+++ b/contracts/StorageContract.sol
@@ -174,6 +174,7 @@ abstract contract StorageContract is DecentralizedKV, AccessControlUpgradeable {
     /// @notice Constructs the StorageContract contract. Initializes the storage config.
     /// @custom:oz-upgrades-unsafe-allow constructor
     constructor(Config memory _config, uint256 _startTime, uint256 _storageCost, uint256 _dcfFactor)
+        /// forge-lint: disable-next-line(incorrect-shift)
         DecentralizedKV(1 << _config.maxKvSizeBits, _startTime, _storageCost, _dcfFactor)
     {
         /* Assumptions */
@@ -254,6 +255,7 @@ abstract contract StorageContract is DecentralizedKV, AccessControlUpgradeable {
         if (_getShardId(totalEntries) > shardId) {
             // We assume the rate limit (e.g., block gas limit) will ensure _batchSize < (1 << SHARD_ENTRY_BITS).
             // i.e., at most one new shard will be created in this Tx.
+            /// forge-lint: disable-next-line(incorrect-shift)
             uint256 kvCountNew = totalEntries % (1 << SHARD_ENTRY_BITS);
             totalPayment += _upfrontPayment(_blockTs()) * kvCountNew; // the shard will use _blockTs() as lastMineTime (see _checkAppend())
             totalPayment += _upfrontPayment($._infos[shardId].lastMineTime) * (_batchSize - kvCountNew);
@@ -372,6 +374,7 @@ abstract contract StorageContract is DecentralizedKV, AccessControlUpgradeable {
         if (_shardId < lastShardIdx) {
             reward = _paymentIn(STORAGE_COST << SHARD_ENTRY_BITS, info.lastMineTime, _minedTs);
         } else if (_shardId == lastShardIdx) {
+            /// forge-lint: disable-next-line(incorrect-shift)
             reward = _paymentIn(STORAGE_COST * (kvEntryCount() % (1 << SHARD_ENTRY_BITS)), info.lastMineTime, _minedTs);
             // Additional prepaid for the last shard
             if ($._prepaidLastMineTime < _minedTs) {

--- a/contracts/StorageContract.sol
+++ b/contracts/StorageContract.sol
@@ -203,7 +203,7 @@ abstract contract StorageContract is DecentralizedKV, AccessControlUpgradeable {
     /// @param _nonceLimit    The maximum nonce per block.
     /// @param _treasury      The treasury address.
     /// @param _owner         The contract owner.
-    function initStorage(
+    function _initStorage(
         uint256 _minimumDiff,
         uint256 _prepaidAmount,
         uint256 _nonceLimit,
@@ -213,7 +213,7 @@ abstract contract StorageContract is DecentralizedKV, AccessControlUpgradeable {
         __AccessControl_init();
         _grantRole(DEFAULT_ADMIN_ROLE, _owner);
 
-        initKv();
+        _initKv();
 
         StorageContractStorage storage $ = _getStorageContractStorage();
         $._minimumDiff = _minimumDiff;

--- a/contracts/libraries/BinaryRelated.sol
+++ b/contracts/libraries/BinaryRelated.sol
@@ -4,6 +4,7 @@ pragma solidity 0.8.28;
 library BinaryRelated {
     function pow(uint256 fp, uint256 n) internal pure returns (uint256) {
         // 1.0 in Q128.128
+        /// forge-lint: disable-next-line(incorrect-shift)
         uint256 v = 1 << 128;
         // we can use unchecked here because we know that fp is in the range [0, 2^128), and it can save gas if n is large
         unchecked {
@@ -25,6 +26,7 @@ library BinaryRelated {
     }
 
     function reverseBits(uint256 bits, uint256 input) internal pure returns (uint256) {
+        /// forge-lint: disable-next-line(incorrect-shift)
         assert(input < (1 << bits));
         uint256 n = input;
         uint256 r = 0;

--- a/contracts/libraries/MerkleLib.sol
+++ b/contracts/libraries/MerkleLib.sol
@@ -6,6 +6,7 @@ import "./BinaryRelated.sol";
 library MerkleLib {
     // Calculate the Merkle root of a given data with chunk size and number of maximum chunks in the data limit.
     function merkleRoot(bytes memory data, uint256 chunkSize, uint256 nChunkBits) internal pure returns (bytes32) {
+        /// forge-lint: disable-next-line(incorrect-shift)
         uint256 nChunks = 1 << nChunkBits;
         bytes32[] memory nodes = new bytes32[](nChunks);
         for (uint256 i = 0; i < nChunks; i++) {
@@ -81,6 +82,7 @@ library MerkleLib {
     {
         bytes32 hash = dataHash;
         uint256 nChunkBits = proofs.length;
+        /// forge-lint: disable-next-line(incorrect-shift)
         require(chunkIdx < (1 << nChunkBits), "chunkId overflows");
         for (uint256 i = 0; i < nChunkBits; i++) {
             if (chunkIdx % 2 == 0) {
@@ -101,6 +103,7 @@ library MerkleLib {
     {
         bytes32 hash = dataHash;
         uint256 nChunkBits = proofs.length;
+        /// forge-lint: disable-next-line(incorrect-shift)
         require(chunkIdx < (1 << nChunkBits), "chunkId overflows");
         for (uint256 i = 0; i < nChunkBits; i++) {
             if (chunkIdx % 2 == 0) {
@@ -119,6 +122,7 @@ library MerkleLib {
         pure
         returns (bytes32[] memory)
     {
+        /// forge-lint: disable-next-line(incorrect-shift)
         uint256 nChunks = 1 << nChunkBits;
         require(chunkIdx < nChunks, "index out of scope");
         bytes32[] memory nodes = new bytes32[](nChunks);

--- a/contracts/libraries/MerkleLib.sol
+++ b/contracts/libraries/MerkleLib.sol
@@ -146,7 +146,8 @@ library MerkleLib {
         uint256 proofIdx = 0;
         bytes32[] memory proofs = new bytes32[](nChunkBits);
         while (n != 1) {
-            proofs[proofIdx] = nodes[(chunkIdx / 2) * 2 + 1 - (chunkIdx % 2)];
+            // Get sibling node for proof: flip last bit (even+1, odd-1)
+            proofs[proofIdx] = nodes[chunkIdx ^ 1];
             for (uint256 i = 0; i < n / 2; i++) {
                 nodes[i] = keccak256(abi.encode(nodes[i * 2], nodes[i * 2 + 1]));
             }

--- a/contracts/libraries/MerkleLib.sol
+++ b/contracts/libraries/MerkleLib.sol
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: MIT
 pragma solidity 0.8.28;
 
-import "./BinaryRelated.sol";
+import {BinaryRelated} from "./BinaryRelated.sol";
 
 library MerkleLib {
     // Calculate the Merkle root of a given data with chunk size and number of maximum chunks in the data limit.

--- a/contracts/libraries/RLPReader.sol
+++ b/contracts/libraries/RLPReader.sol
@@ -6,6 +6,8 @@
  */
 pragma solidity 0.8.28;
 
+///forge-lint: disable-next-item(pascal-case-struct)
+
 library RLPReader {
     uint8 constant STRING_SHORT_START = 0x80;
     uint8 constant STRING_LONG_START = 0xb8;

--- a/contracts/libraries/RandaoLib.sol
+++ b/contracts/libraries/RandaoLib.sol
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: MIT
 pragma solidity 0.8.28;
 
-import "./RLPReader.sol";
+import {RLPReader} from "./RLPReader.sol";
 
 /// @title RandaoLib
 /// @notice Handles Randao related operations

--- a/contracts/test/DecentralizedKVTest.t.sol
+++ b/contracts/test/DecentralizedKVTest.t.sol
@@ -1,18 +1,18 @@
 // SPDX-License-Identifier: UNLICENSED
 pragma solidity 0.8.28;
 
-import "./TestDecentralizedKV.sol";
-import "forge-std/Test.sol";
+import {TestDecentralizedKV} from "./TestDecentralizedKV.sol";
+import {Test} from "forge-std/Test.sol";
 
 contract DecentralizedKVTest is Test {
     uint256 constant MAX_KV_SIZE = 17;
     uint256 constant STORAGE_COST = 10000000;
     uint256 constant SHARD_SIZE_BITS = 19;
     uint256 constant PREPAID_AMOUNT = 2 * STORAGE_COST;
-    TestDecentralizedKV decentralizedKV;
+    TestDecentralizedKV decentralizedKv;
 
     function setUp() public {
-        decentralizedKV = new TestDecentralizedKV(MAX_KV_SIZE, 0, STORAGE_COST, 340282366367469178095360967382638002176);
-        decentralizedKV.initialize();
+        decentralizedKv = new TestDecentralizedKV(MAX_KV_SIZE, 0, STORAGE_COST, 340282366367469178095360967382638002176);
+        decentralizedKv.initialize();
     }
 }

--- a/contracts/test/EthStorageContractL2Test.t.sol
+++ b/contracts/test/EthStorageContractL2Test.t.sol
@@ -1,9 +1,12 @@
 // SPDX-License-Identifier: MIT
 pragma solidity 0.8.28;
 
-import "forge-std/Test.sol";
-import "./TestEthStorageContractM2L2.sol";
-import "openzeppelin-foundry-upgrades/Upgrades.sol";
+import {Test} from "forge-std/Test.sol";
+import {StorageContract} from "../StorageContract.sol";
+import {L2Base} from "../L2Base.sol";
+import {TestEthStorageContractM2L2} from "./TestEthStorageContractM2L2.sol";
+import {EthStorageContractM2L2} from "../EthStorageContractM2L2.sol";
+import {Upgrades, Options, TransparentUpgradeableProxy} from "openzeppelin-foundry-upgrades/Upgrades.sol";
 
 contract SoulGasToken {
     function chargeFromOrigin(uint256 _amount) external pure returns (uint256) {

--- a/contracts/test/EthStorageContractM1Test.t.sol
+++ b/contracts/test/EthStorageContractM1Test.t.sol
@@ -1,9 +1,10 @@
 // SPDX-License-Identifier: UNLICENSED
 pragma solidity 0.8.28;
 
-import "./TestEthStorageContractM1.sol";
-import "forge-std/Test.sol";
-import "openzeppelin-foundry-upgrades/Upgrades.sol";
+import {TestEthStorageContractM1} from "./TestEthStorageContractM1.sol";
+import {Test} from "forge-std/Test.sol";
+import {Upgrades, Options} from "openzeppelin-foundry-upgrades/Upgrades.sol";
+import {StorageContract} from "../StorageContract.sol";
 
 contract EthStorageContractM1Test is Test {
     uint256 constant STORAGE_COST = 1000;

--- a/contracts/test/EthStorageContractM1Test.t.sol
+++ b/contracts/test/EthStorageContractM1Test.t.sol
@@ -45,6 +45,7 @@ contract EthStorageContractM1Test is Test {
         storageContract.putBlob{value: sufficientCost}(key, blobIdx, length);
 
         assertEq(storageContract.kvEntryCount(), 1);
+        /// forge-lint: disable-next-line(incorrect-shift)
         assertEq(storageContract.hash(key), bytes32(uint256(1 << 8 * 8)));
         assertEq(storageContract.size(key), 10);
 
@@ -54,6 +55,7 @@ contract EthStorageContractM1Test is Test {
         sufficientCost = storageContract.upfrontPayment();
         storageContract.putBlob{value: sufficientCost}(key, blobIdx, length);
         assertEq(storageContract.kvEntryCount(), 2);
+        /// forge-lint: disable-next-line(incorrect-shift)
         assertEq(storageContract.hash(key), bytes32(uint256(1 << 8 * 8)));
         assertEq(storageContract.size(key), 20);
     }
@@ -80,8 +82,10 @@ contract EthStorageContractM1Test is Test {
         storageContract.putBlobs{value: sufficientCost}(keys, blobIdxs, lengths);
 
         assertEq(storageContract.kvEntryCount(), 2);
+        /// forge-lint: disable-start(incorrect-shift)
         assertEq(storageContract.hash(keys[0]), bytes32(uint256(1 << 8 * 8)));
         assertEq(storageContract.hash(keys[1]), bytes32(uint256(2 << 8 * 8)));
+        /// forge-lint: disable-end(incorrect-shift)
         assertEq(storageContract.size(keys[0]), 10);
         assertEq(storageContract.size(keys[1]), 20);
 
@@ -93,9 +97,11 @@ contract EthStorageContractM1Test is Test {
         sufficientCost = storageContract.upfrontPayment();
         storageContract.putBlobs{value: sufficientCost}(keys, blobIdxs, lengths);
         assertEq(storageContract.kvEntryCount(), 3);
+        /// forge-lint: disable-start(incorrect-shift)
         assertEq(storageContract.hash(bytes32(uint256(0))), bytes32(uint256(1 << 8 * 8)));
         assertEq(storageContract.hash(bytes32(uint256(1))), bytes32(uint256(2 << 8 * 8)));
         assertEq(storageContract.hash(bytes32(uint256(2))), bytes32(uint256(2 << 8 * 8)));
+        /// forge-lint: disable-end(incorrect-shift)
         assertEq(storageContract.size(bytes32(uint256(0))), 30);
         assertEq(storageContract.size(bytes32(uint256(1))), 20);
         assertEq(storageContract.size(bytes32(uint256(2))), 30);

--- a/contracts/test/StorageContractTest.t.sol
+++ b/contracts/test/StorageContractTest.t.sol
@@ -1,9 +1,9 @@
 // SPDX-License-Identifier: UNLICENSED
 pragma solidity 0.8.28;
 
-import "./TestStorageContract.sol";
-import "../StorageContract.sol";
-import "forge-std/Test.sol";
+import {TestStorageContract} from "./TestStorageContract.sol";
+import {StorageContract} from "../StorageContract.sol";
+import {Test} from "forge-std/Test.sol";
 
 contract StorageContractTest is Test {
     uint256 constant STORAGE_COST = 10000000;

--- a/contracts/test/TestDecentralizedKV.sol
+++ b/contracts/test/TestDecentralizedKV.sol
@@ -13,7 +13,7 @@ contract TestDecentralizedKV is DecentralizedKV {
     {}
 
     function initialize() public initializer {
-        initKv();
+        _initKv();
     }
 
     function setTimestamp(uint256 ts) public {

--- a/contracts/test/TestDecentralizedKV.sol
+++ b/contracts/test/TestDecentralizedKV.sol
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: MIT
 pragma solidity 0.8.28;
 
-import "../DecentralizedKV.sol";
+import {DecentralizedKV} from "../DecentralizedKV.sol";
 
 contract TestDecentralizedKV is DecentralizedKV {
     uint256 public currentTimestamp;
@@ -13,7 +13,7 @@ contract TestDecentralizedKV is DecentralizedKV {
     {}
 
     function initialize() public initializer {
-        __init_KV();
+        initKv();
     }
 
     function setTimestamp(uint256 ts) public {

--- a/contracts/test/TestEthStorageContractM1.sol
+++ b/contracts/test/TestEthStorageContractM1.sol
@@ -49,6 +49,7 @@ contract TestEthStorageContractM1 is EthStorageContractM1 {
     }
 
     function putBlob(bytes32 _key, uint256, /* _blobIdx */ uint256 _length) public payable override {
+        /// forge-lint: disable-next-line(incorrect-shift)
         bytes32 dataHash = bytes32(uint256(1 << 8 * 8));
         require(dataHash != 0, "EthStorageContract: failed to get blob hash");
 
@@ -74,6 +75,7 @@ contract TestEthStorageContractM1 is EthStorageContractM1 {
 
         bytes32[] memory dataHashes = new bytes32[](_blobIdxs.length);
         for (uint256 i = 0; i < _blobIdxs.length; i++) {
+            /// forge-lint: disable-next-line(incorrect-shift)
             dataHashes[i] = bytes32(i + 1 << 8 * 8); // dummy data hash
             require(dataHashes[i] != 0, "EthStorageContract: failed to get blob hash");
         }
@@ -156,11 +158,13 @@ contract TestEthStorageContractM1 is EthStorageContractM1 {
 
     function getSampleIdx(uint256 startShardId, bytes32 hash0) public view returns (uint256, uint256, uint256) {
         // calculate the number of samples range of the sample check
+        /// forge-lint: disable-next-line(incorrect-shift)
         uint256 rows = 1 << (SHARD_ENTRY_BITS + SAMPLE_LEN_BITS); // kvNumbersPerShard * smapleNumersPerKV
 
         uint256 parent = uint256(hash0) % rows;
         uint256 sampleIdx = parent + (startShardId << (SHARD_ENTRY_BITS + SAMPLE_LEN_BITS));
         uint256 kvIdx = sampleIdx >> SAMPLE_LEN_BITS;
+        /// forge-lint: disable-next-line(incorrect-shift)
         uint256 sampleIdxInKv = sampleIdx % (1 << SAMPLE_LEN_BITS);
 
         return (sampleIdx, kvIdx, sampleIdxInKv);

--- a/contracts/test/TestEthStorageContractM1.sol
+++ b/contracts/test/TestEthStorageContractM1.sol
@@ -1,8 +1,8 @@
 // SPDX-License-Identifier: MIT
 pragma solidity 0.8.28;
 
-import "../EthStorageContractM1.sol";
-import "../libraries/MerkleLib.sol";
+import {EthStorageContractM1} from "../EthStorageContractM1.sol";
+import {MerkleLib} from "../libraries/MerkleLib.sol";
 
 contract TestEthStorageContractM1 is EthStorageContractM1 {
     uint256 public currentTimestamp;

--- a/contracts/test/TestEthStorageContractM2.sol
+++ b/contracts/test/TestEthStorageContractM2.sol
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: MIT
 pragma solidity 0.8.28;
 
-import "../EthStorageContractM2.sol";
+import {EthStorageContractM2} from "../EthStorageContractM2.sol";
 
 contract TestEthStorageContractM2 is EthStorageContractM2 {
     constructor(Config memory _config, uint256 _startTime, uint256 _storageCost, uint256 _dcfFactor)

--- a/contracts/test/TestEthStorageContractM2L2.sol
+++ b/contracts/test/TestEthStorageContractM2L2.sol
@@ -1,10 +1,10 @@
 // SPDX-License-Identifier: MIT
 pragma solidity 0.8.28;
 
-import "../EthStorageContractM2L2.sol";
+import {EthStorageContractM2L2} from "../EthStorageContractM2L2.sol";
 // import "forge-std/Test.sol"; // will cause https://zpl.in/upgrades/error-004
 // So we use the base contract directly
-import "forge-std/Base.sol";
+import {CommonBase} from "forge-std/Base.sol";
 
 contract TestEthStorageContractM2L2 is EthStorageContractM2L2, CommonBase {
     /// @custom:oz-upgrades-unsafe-allow constructor

--- a/contracts/test/TestMerkleLib.sol
+++ b/contracts/test/TestMerkleLib.sol
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: MIT
 pragma solidity 0.8.28;
 
-import "../libraries/MerkleLib.sol";
+import {MerkleLib} from "../libraries/MerkleLib.sol";
 
 contract TestMerkleLib {
     function merkleRoot(bytes memory data, uint256 chunkSize, uint256 nChunkBits) public pure returns (bytes32) {

--- a/contracts/test/TestRandao.sol
+++ b/contracts/test/TestRandao.sol
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: MIT
 pragma solidity 0.8.28;
 
-import "../libraries/RandaoLib.sol";
+import {RandaoLib} from "../libraries/RandaoLib.sol";
 
 contract TestRandao {
     function verifyHeaderAndGetRandao(bytes32 headerHash, bytes memory headerRlpBytes) public pure returns (bytes32) {

--- a/contracts/test/TestStorageContract.sol
+++ b/contracts/test/TestStorageContract.sol
@@ -15,7 +15,7 @@ contract TestStorageContract is StorageContract {
         address _treasury,
         address _owner
     ) public payable initializer {
-        initStorage(_minimumDiff, _prepaidAmount, _nonceLimit, _treasury, _owner);
+        _initStorage(_minimumDiff, _prepaidAmount, _nonceLimit, _treasury, _owner);
     }
 
     function verifySamples(

--- a/contracts/test/TestStorageContract.sol
+++ b/contracts/test/TestStorageContract.sol
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: MIT
 pragma solidity 0.8.28;
 
-import "../StorageContract.sol";
+import {StorageContract} from "../StorageContract.sol";
 
 contract TestStorageContract is StorageContract {
     constructor(Config memory _config, uint256 _startTime, uint256 _storageCost, uint256 _dcfFactor)
@@ -15,7 +15,7 @@ contract TestStorageContract is StorageContract {
         address _treasury,
         address _owner
     ) public payable initializer {
-        __init_storage(_minimumDiff, _prepaidAmount, _nonceLimit, _treasury, _owner);
+        initStorage(_minimumDiff, _prepaidAmount, _nonceLimit, _treasury, _owner);
     }
 
     function verifySamples(

--- a/contracts/zk-verify/Decoder.sol
+++ b/contracts/zk-verify/Decoder.sol
@@ -20,6 +20,8 @@
 
 pragma solidity 0.8.28;
 
+/// forge-lint: disable-next-item(screaming-snake-case-const)
+
 contract Decoder {
     // Scalar field size
     uint256 constant r = 21888242871839275222246405745257275088548364400416034343698204186575808495617;

--- a/contracts/zk-verify/Decoder2.sol
+++ b/contracts/zk-verify/Decoder2.sol
@@ -20,6 +20,8 @@
 
 pragma solidity 0.8.28;
 
+/// forge-lint: disable-next-item(screaming-snake-case-const)
+
 contract Decoder2 {
     // Scalar field size
     uint256 constant r = 21888242871839275222246405745257275088548364400416034343698204186575808495617;

--- a/foundry.toml
+++ b/foundry.toml
@@ -16,7 +16,3 @@ fs_permissions = [
 ]
 optimizer = true
 optimizer_runs = 200
-
-[lint]
-severity = ["high"]
-exclude_lints = ["incorrect-shift"]

--- a/script/Deploy.s.sol
+++ b/script/Deploy.s.sol
@@ -1,14 +1,15 @@
 // SPDX-License-Identifier: MIT
 pragma solidity 0.8.28;
 
-import "forge-std/Script.sol";
-import "forge-std/console.sol";
-import "openzeppelin-foundry-upgrades/Upgrades.sol";
+import {Script} from "forge-std/Script.sol";
+import {console} from "forge-std/console.sol";
+import {Upgrades, Options} from "openzeppelin-foundry-upgrades/Upgrades.sol";
 
-import "../contracts/EthStorageContractM1.sol";
-import "../contracts/EthStorageContractM1L2.sol";
-import "../contracts/EthStorageContractM2.sol";
-import "../contracts/EthStorageContractM2L2.sol";
+import {EthStorageContractM1} from "../contracts/EthStorageContractM1.sol";
+import {EthStorageContractM1L2} from "../contracts/EthStorageContractM1L2.sol";
+import {EthStorageContractM2} from "../contracts/EthStorageContractM2.sol";
+import {EthStorageContractM2L2} from "../contracts/EthStorageContractM2L2.sol";
+import {StorageContract} from "../contracts/StorageContract.sol";
 
 contract Deploy is Script {
     uint256 private deployerPrivateKey;
@@ -31,16 +32,16 @@ contract Deploy is Script {
         address owner = vm.envOr("OWNER_ADDRESS", deployer);
         uint256 startTime = block.timestamp;
 
-        string memory contractFQN;
+        string memory contractFullName;
         bytes memory constructorData;
         bytes memory initData;
 
-        (contractFQN, constructorData, initData) = _getDeploymentData(contractName, deployer, startTime);
+        (contractFullName, constructorData, initData) = _getDeploymentData(contractName, deployer, startTime);
         Options memory opts;
         opts.constructorData = constructorData;
 
         vm.startBroadcast(deployerPrivateKey);
-        address proxy = Upgrades.deployTransparentProxy(contractFQN, owner, initData, opts);
+        address proxy = Upgrades.deployTransparentProxy(contractFullName, owner, initData, opts);
         vm.stopBroadcast();
 
         console.log("Proxy address:", proxy);
@@ -55,16 +56,16 @@ contract Deploy is Script {
         console.log("Proxy address:", proxyAddress);
         uint256 startTime = vm.envUint("START_TIME");
 
-        string memory contractFQN;
+        string memory contractFullName;
         bytes memory constructorData;
-        (contractFQN, constructorData,) = _getDeploymentData(contractName, deployer, startTime);
+        (contractFullName, constructorData,) = _getDeploymentData(contractName, deployer, startTime);
         Options memory opts;
         opts.constructorData = constructorData;
 
         opts.referenceBuildInfoDir = vm.envString("REFERENCE_BUILD_INFO_DIR");
         opts.referenceContract = vm.envString("REFERENCE_CONTRACT");
         vm.startBroadcast(deployerPrivateKey);
-        Upgrades.upgradeProxy(proxyAddress, contractFQN, "", opts);
+        Upgrades.upgradeProxy(proxyAddress, contractFullName, "", opts);
 
         console.log("Upgrade completed successfully!");
         address newImpl = Upgrades.getImplementationAddress(proxyAddress);
@@ -76,16 +77,16 @@ contract Deploy is Script {
     function prepareUpgrade() external {
         uint256 startTime = vm.envUint("START_TIME");
 
-        string memory contractFQN;
+        string memory contractFullName;
         bytes memory constructorData;
-        (contractFQN, constructorData,) = _getDeploymentData(contractName, deployer, startTime);
+        (contractFullName, constructorData,) = _getDeploymentData(contractName, deployer, startTime);
         Options memory opts;
         opts.constructorData = constructorData;
         opts.referenceBuildInfoDir = vm.envString("REFERENCE_BUILD_INFO_DIR");
         opts.referenceContract = vm.envString("REFERENCE_CONTRACT");
 
         vm.startBroadcast(deployerPrivateKey);
-        address newImpl = Upgrades.prepareUpgrade(contractFQN, opts);
+        address newImpl = Upgrades.prepareUpgrade(contractFullName, opts);
         console.log("New implementation address:", newImpl);
         vm.stopBroadcast();
     }
@@ -123,7 +124,7 @@ contract Deploy is Script {
     function _getDeploymentData(string memory _contractName, address _deployer, uint256 startTime)
         internal
         view
-        returns (string memory contractFQN, bytes memory constructorData, bytes memory initData)
+        returns (string memory contractFullName, bytes memory constructorData, bytes memory initData)
     {
         StorageContract.Config memory config = StorageContract.Config({
             maxKvSizeBits: vm.envUint("MAX_KV_SIZE_BITS"),
@@ -150,32 +151,32 @@ contract Deploy is Script {
         bytes32 nameHash = keccak256(bytes(_contractName));
 
         if (nameHash == keccak256("EthStorageContractM1")) {
-            contractFQN = "EthStorageContractM1.sol:EthStorageContractM1";
+            contractFullName = "EthStorageContractM1.sol:EthStorageContractM1";
             initData = abi.encodeWithSelector(
                 EthStorageContractM1.initialize.selector, minimumDiff, prepaidAmount, nonceLimit, treasury, owner
             );
             constructorData = abi.encode(config, startTime, storageCost, dcfFactor);
         } else if (nameHash == keccak256("EthStorageContractM1L2")) {
             uint256 updateLimit = vm.envUint("UPDATE_LIMIT");
-            contractFQN = "EthStorageContractM1L2.sol:EthStorageContractM1L2";
+            contractFullName = "EthStorageContractM1L2.sol:EthStorageContractM1L2";
             initData = abi.encodeWithSelector(
                 EthStorageContractM1L2.initialize.selector, minimumDiff, prepaidAmount, nonceLimit, treasury, owner
             );
             constructorData = abi.encode(config, startTime, storageCost, dcfFactor, updateLimit);
         } else if (nameHash == keccak256("EthStorageContractM2")) {
-            contractFQN = "EthStorageContractM2.sol:EthStorageContractM2";
+            contractFullName = "EthStorageContractM2.sol:EthStorageContractM2";
             initData = abi.encodeWithSelector(
                 EthStorageContractM2.initialize.selector, minimumDiff, prepaidAmount, nonceLimit, treasury, owner
             );
             constructorData = abi.encode(config, startTime, storageCost, dcfFactor);
         } else if (nameHash == keccak256("EthStorageContractM2L2")) {
             uint256 updateLimit = vm.envUint("UPDATE_LIMIT");
-            contractFQN = "EthStorageContractM2L2.sol:EthStorageContractM2L2";
+            contractFullName = "EthStorageContractM2L2.sol:EthStorageContractM2L2";
             initData = abi.encodeWithSelector(
                 EthStorageContractM2L2.initialize.selector, minimumDiff, prepaidAmount, nonceLimit, treasury, owner
             );
             constructorData = abi.encode(config, startTime, storageCost, dcfFactor, updateLimit);
         }
-        return (contractFQN, constructorData, initData);
+        return (contractFullName, constructorData, initData);
     }
 }


### PR DESCRIPTION
Fix basically 2 types of note:
1. note[unaliased-plain-import]: use named imports '{A, B}' or alias 'import ".." as X'
2. variable cases like - note[screaming-snake-case-const]: constants should use SCREAMING_SNAKE_CASE
