### PR TITLE
fix full shard reward

### DIFF
--- a/contracts/StorageContract.sol
+++ b/contracts/StorageContract.sol
@@ -366,7 +366,8 @@ abstract contract StorageContract is DecentralizedKV, AccessControlUpgradeable {
     {
         StorageContractStorage storage $ = _getStorageContractStorage();
         MiningLib.MiningInfo storage info = $._infos[_shardId];
-        uint256 lastShardIdx = _getShardId(kvEntryCount());
+        uint256 kvCount = kvEntryCount();
+        uint256 lastShardIdx = _getShardId(kvCount);
         bool updatePrepaidTime = false;
         uint256 prepaidAmountSaved = 0;
         uint256 reward = 0;
@@ -374,7 +375,9 @@ abstract contract StorageContract is DecentralizedKV, AccessControlUpgradeable {
             reward = _paymentIn(STORAGE_COST << SHARD_ENTRY_BITS, info.lastMineTime, _minedTs);
         } else if (_shardId == lastShardIdx) {
             /// forge-lint: disable-next-line(incorrect-shift)
-            reward = _paymentIn(STORAGE_COST * (kvEntryCount() % (1 << SHARD_ENTRY_BITS)), info.lastMineTime, _minedTs);
+            uint256 shardEntryCount = 1 << SHARD_ENTRY_BITS;
+            uint256 entriesInLastShard = kvCount == 0 ? 0 : ((kvCount - 1) % shardEntryCount) + 1;
+            reward = _paymentIn(STORAGE_COST * entriesInLastShard, info.lastMineTime, _minedTs);
             // Additional prepaid for the last shard
             if ($._prepaidLastMineTime < _minedTs) {
                 uint256 fullReward = _paymentIn(STORAGE_COST << SHARD_ENTRY_BITS, info.lastMineTime, _minedTs);

--- a/contracts/test/StorageContractTest.t.sol
+++ b/contracts/test/StorageContractTest.t.sol
@@ -59,6 +59,20 @@ contract StorageContractTest is Test {
         storageContract.setKvEntryCount(3);
         (,,, reward) = storageContract.miningRewards(0, 1);
         assertEq(reward, storageContract.paymentIn(PREPAID_AMOUNT + STORAGE_COST * 2, 0, 1));
+
+        // full shard reward has no prepaid
+        uint256 mineTs = 10000;
+        uint256 expectedFullShardReward = storageContract.paymentIn(STORAGE_COST * 4, 0, mineTs);
+
+        // 4 key-value stored on EthStorage fill shard
+        storageContract.setKvEntryCount(4);
+        (,,, reward) = storageContract.miningRewards(0, mineTs);
+        assertEq(reward, expectedFullShardReward);
+
+        // 8 key-value stored on EthStorage fill 2 shards
+        storageContract.setKvEntryCount(8);
+        (,,, reward) = storageContract.miningRewards(0, mineTs);
+        assertEq(reward, expectedFullShardReward);
     }
 
     function testWithdraw() public {

--- a/hardhat.config.js
+++ b/hardhat.config.js
@@ -85,6 +85,7 @@ module.exports = {
   solidity: {
     version: "0.8.28",
     settings: {
+      viaIR: true,
       optimizer: {
         enabled: true,
         runs: 200,


### PR DESCRIPTION
**Issue**

The `_miningReward` returns zero KV-portion when the last shard is exactly full, due to the expression `kvEntryCount() % shardSize` evaluating to zero whenever `kvEntryCount()` is a non-zero multiple of the shard size. For details refer to [this page](https://github.com/ethstorage/storage-contracts-v1/security/advisories/GHSA-h7f9-3cw8-vvgw).


**Tests**

Forge test cases have been added for the full shard reward.

Before the fix:
>[FAIL: assertion failed: 325 != 650] testMiningReward() 

After the fix:
>[PASS] testMiningReward()